### PR TITLE
Various small changes in core::gc

### DIFF
--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -14,6 +14,10 @@ pub trait Conservative {}
 pub trait NoFinalize {}
 
 #[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(bootstrap), lang = "notrace")]
+pub auto trait NoTrace {}
+
+#[unstable(feature = "gc", issue = "none")]
 #[cfg(not(bootstrap))]
 /// Returns a pair describing the layout of the type for use by the collector.
 ///
@@ -25,10 +29,6 @@ pub unsafe fn gc_layout<T>() -> (u64, u64) {
     let layout = crate::intrinsics::gc_layout::<T>();
     (layout[0], layout[1])
 }
-
-#[unstable(feature = "gc", issue = "none")]
-#[cfg_attr(not(bootstrap), lang = "notrace")]
-pub auto trait NoTrace {}
 
 impl !NoTrace for usize {}
 

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -2,12 +2,8 @@
 #![allow(missing_docs)]
 
 #[cfg(not(bootstrap))]
-use crate::intrinsics;
-#[cfg(not(bootstrap))]
-use crate::mem::size_of;
+static MAX_LAYOUT: usize = crate::mem::size_of::<usize>() * 64;
 
-#[cfg(not(bootstrap))]
-static MAX_LAYOUT: usize = size_of::<usize>() * 64;
 
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(bootstrap), lang = "manageable_contents")]
@@ -28,8 +24,8 @@ pub trait NoFinalize {}
 ///
 /// The type T must be smaller or equal in size to `size_of::<usize> * 64`.
 pub unsafe fn gc_layout<T>() -> (u64, u64) {
-    debug_assert!(size_of::<T>() <= MAX_LAYOUT);
-    let layout = intrinsics::gc_layout::<T>();
+    debug_assert!(crate::mem::size_of::<T>() <= MAX_LAYOUT);
+    let layout = crate::intrinsics::gc_layout::<T>();
     (layout[0], layout[1])
 }
 

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -6,13 +6,6 @@ static MAX_LAYOUT: usize = crate::mem::size_of::<usize>() * 64;
 
 
 #[unstable(feature = "gc", issue = "none")]
-#[cfg_attr(not(bootstrap), lang = "manageable_contents")]
-/// This trait can be implemented on types where it is safe to allow the allow the collector to
-/// free its memory and omit the drop method. This prevents the need to register a finalizer when
-/// managed by the Gc which is expensive.
-pub trait ManageableContents {}
-
-#[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(bootstrap), lang = "no_finalize")]
 pub trait NoFinalize {}
 

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -4,6 +4,10 @@
 #[cfg(not(bootstrap))]
 static MAX_LAYOUT: usize = crate::mem::size_of::<usize>() * 64;
 
+#[unstable(feature = "gc", issue = "none")]
+/// A type that implements this trait will be conservatively marked by the
+/// collector. This takes precedence over `NoTrace`.
+pub trait Conservative {}
 
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(bootstrap), lang = "no_finalize")]

--- a/src/test/ui/layout/gc-layout.rs
+++ b/src/test/ui/layout/gc-layout.rs
@@ -1,4 +1,5 @@
 // run-pass
+// ignore-tidy-linelength
 
 #![feature(gc)]
 
@@ -6,7 +7,7 @@
 #![allow(unused_attributes)]
 #![allow(unused_imports)]
 
-use std::gc::gc_layout;
+use std::gc::{gc_layout, Trace};
 use std::mem::size_of;
 use std::mem::align_of;
 
@@ -97,21 +98,20 @@ fn main() {
     assert_eq!(size_of::<BigAlignNoTrace>(), 40);
 
     unsafe {
-                                                       // Bitmap,   Size (words)
-    assert_eq!(gc_layout::<SmallAlign>(),              (0x0000000000000000, 0));
-    assert_eq!(gc_layout::<ShuffledFields>(),          (0xFFFFFFFFFFFFFFFD, 2));
-    assert_eq!(gc_layout::<ShuffledFieldsNoTrace>(),   (0xFFFFFFFFFFFFFFFC, 2));
-    assert_eq!(gc_layout::<FixedFields>(),             (0xFFFFFFFFFFFFFFFA, 3));
-    assert_eq!(gc_layout::<FixedFieldsNoTrace>(),      (0xFFFFFFFFFFFFFFF8, 3));
-    assert_eq!(gc_layout::<MultiFields>(),             (0xFFFFFFFFFFFFFFF9, 3));
-    assert_eq!(gc_layout::<BigAlign>(),                (0xFFFFFFFFFFFFFFFF, 5));
-    assert_eq!(gc_layout::<BigAlignNoTrace>(),         (0xFFFFFFFFFFFFFFE3, 5));
+    assert_eq!(gc_layout::<SmallAlign>(),              Trace { bitmap: 0x0000000000000000, size: 0 });
+    assert_eq!(gc_layout::<ShuffledFields>(),          Trace { bitmap: 0xFFFFFFFFFFFFFFFD, size: 2 });
+    assert_eq!(gc_layout::<ShuffledFieldsNoTrace>(),   Trace { bitmap: 0xFFFFFFFFFFFFFFFC, size: 2 });
+    assert_eq!(gc_layout::<FixedFields>(),             Trace { bitmap: 0xFFFFFFFFFFFFFFFA, size: 3 });
+    assert_eq!(gc_layout::<FixedFieldsNoTrace>(),      Trace { bitmap: 0xFFFFFFFFFFFFFFF8, size: 3 });
+    assert_eq!(gc_layout::<MultiFields>(),             Trace { bitmap: 0xFFFFFFFFFFFFFFF9, size: 3 });
+    assert_eq!(gc_layout::<BigAlign>(),                Trace { bitmap: 0xFFFFFFFFFFFFFFFF, size: 5 });
+    assert_eq!(gc_layout::<BigAlignNoTrace>(),         Trace { bitmap: 0xFFFFFFFFFFFFFFE3, size: 5 });
 
-    assert_eq!(gc_layout::<NoTraceInner>(),            (0x0000000000000000, 0));
-    assert_eq!(gc_layout::<NoTraceOuter>(),            (0xFFFFFFFFFFFFFFF9, 3));
-    assert_eq!(gc_layout::<NoTraceOuter2>(),           (0x0000000000000000, 0));
+    assert_eq!(gc_layout::<NoTraceInner>(),            Trace { bitmap: 0x0000000000000000, size: 0 });
+    assert_eq!(gc_layout::<NoTraceOuter>(),            Trace { bitmap: 0xFFFFFFFFFFFFFFF9, size: 3 });
+    assert_eq!(gc_layout::<NoTraceOuter2>(),           Trace { bitmap: 0x0000000000000000, size: 0 });
 
-    assert_eq!(gc_layout::<ZST>(),                     (0x0000000000000000, 0));
+    assert_eq!(gc_layout::<ZST>(),                     Trace { bitmap: 0x0000000000000000, size: 0 });
 
     }
 }


### PR DESCRIPTION
The major changes here are the API change in `gc_layout::<T>` to now return a `Trace` struct, and the addition of the `Conservative` trait.