### PR TITLE
Revert libgc_internal crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,6 @@ version = "0.0.0"
 dependencies = [
  "compiler_builtins",
  "core",
- "libgc_internal",
  "rand",
  "rand_xorshift",
 ]
@@ -1717,15 +1716,6 @@ version = "0.2.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 dependencies = [
- "rustc-std-workspace-core",
-]
-
-[[package]]
-name = "libgc_internal"
-version = "0.1.0"
-source = "git+https://github.com/softdevteam/libgc_internal#cbf33df99760b284fd8fbd8d00afbf35044808da"
-dependencies = [
- "compiler_builtins",
  "rustc-std-workspace-core",
 ]
 
@@ -4695,7 +4685,6 @@ dependencies = [
  "hashbrown",
  "hermit-abi",
  "libc",
- "libgc_internal",
  "miniz_oxide",
  "object",
  "panic_abort",

--- a/library/alloc/Cargo.toml
+++ b/library/alloc/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2018"
 
 [dependencies]
 core = { path = "../core" }
-libgc_internal = { git = "https://github.com/softdevteam/libgc_internal", features = ['rustgc'] }
 compiler_builtins = { version = "0.1.10", features = ['rustc-dep-of-std'] }
 
 [dev-dependencies]

--- a/library/alloc/src/lib.rs
+++ b/library/alloc/src/lib.rs
@@ -150,9 +150,6 @@ extern crate std;
 #[cfg(test)]
 extern crate test;
 
-#[allow(unused_extern_crates)]
-extern crate libgc_internal;
-
 // Module with internal macros used by other modules (needs to be included before other modules).
 #[macro_use]
 mod macros;

--- a/library/std/Cargo.toml
+++ b/library/std/Cargo.toml
@@ -12,7 +12,6 @@ crate-type = ["dylib", "rlib"]
 
 [dependencies]
 alloc = { path = "../alloc" }
-libgc_internal = { git = "https://github.com/softdevteam/libgc_internal", features = ['rustgc'] }
 cfg-if = { version = "0.1.8", features = ['rustc-dep-of-std'] }
 panic_unwind = { path = "../panic_unwind", optional = true }
 panic_abort = { path = "../panic_abort" }

--- a/src/tools/tidy/src/deps.rs
+++ b/src/tools/tidy/src/deps.rs
@@ -114,7 +114,6 @@ const PERMITTED_DEPENDENCIES: &[&str] = &[
     "kernel32-sys",
     "lazy_static",
     "libc",
-    "libgc_internal",
     "libz-sys",
     "lock_api",
     "log",

--- a/src/tools/tidy/src/extdeps.rs
+++ b/src/tools/tidy/src/extdeps.rs
@@ -25,12 +25,6 @@ pub fn check(root: &Path, bad: &mut bool) {
         // Extract source value.
         let source = line.split_once('=').unwrap().1.trim();
 
-        // rustc only permits crates from crates.io so for now libgc_internal is
-        // hardcoded to pass the tidy checker.
-        if source.contains("softdevteam/libgc_internal") {
-            continue;
-        }
-
         // Ensure source is allowed.
         if !ALLOWED_SOURCES.contains(&&*source) {
             println!("invalid source: {}", source);


### PR DESCRIPTION
This is difficult one to raise, because the libgc_internal work was quite a lot of work to implement. However, it's a sunk cost. In doing the work for https://github.com/softdevteam/rustgc/pull/23, I worked out that rustgc doesn't actually need to know the exact implementation details of the Allocator API. This greatly simplifies things, as we won't need to maintain 3 separate repositories and worry about raising PRs in the correct order.