### PR TITLE
Bump LLVM after alloc optimisation fix

### DIFF
--- a/src/test/codegen/alloc-optimisation.rs
+++ b/src/test/codegen/alloc-optimisation.rs
@@ -1,4 +1,3 @@
-// ignore-test
 // no-system-llvm
 // compile-flags: -O
 #![crate_type="lib"]

--- a/src/test/codegen/vec-optimizes-away.rs
+++ b/src/test/codegen/vec-optimizes-away.rs
@@ -1,4 +1,3 @@
-// ignore-test
 // ignore-debug: the debug assertions get in the way
 // no-system-llvm
 // compile-flags: -O


### PR DESCRIPTION
This also lets us re-enable the tests.