### PR TITLE
Prevent early finalization

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -208,6 +208,7 @@ language_item_table! {
 
     NoTrace,                 sym::notrace,             no_trace_trait,             Target::Trait;
     Conservative,            sym::conservative,        conservative_trait,         Target::Trait;
+    GcSmartPointer,          sym::gcsp,                gc_smart_pointer_trait,     Target::Trait;
 
     CoerceUnsized,           sym::coerce_unsized,      coerce_unsized_trait,       Target::Trait;
     DispatchFromDyn,         sym::dispatch_from_dyn,   dispatch_from_dyn_trait,    Target::Trait;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1060,6 +1060,10 @@ rustc_queries! {
         query is_conservative_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` is `Conservative`", env.value }
         }
+        /// Query backing `TyS::is_gc_smart_pointer`.
+        query is_gc_smart_pointer_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+            desc { "computing whether `{}` is `GcSmartPointer`", env.value }
+        }
         /// Query backing `TyS::needs_drop`.
         query needs_drop_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
             desc { "computing whether `{}` needs drop", env.value }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -755,6 +755,14 @@ impl<'tcx> ty::TyS<'tcx> {
         !self.is_conservative(tcx_at, param_env)
     }
 
+    pub fn is_gc_smart_pointer(
+        &'tcx self,
+        tcx_at: TyCtxtAt<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+    ) -> bool {
+        tcx_at.is_gc_smart_pointer_raw(param_env.and(self))
+    }
+
     /// Fast path helper for testing if a type is `Freeze`.
     ///
     /// Returning true means the type is known to be `Freeze`. Returning

--- a/compiler/rustc_mir/src/transform/mod.rs
+++ b/compiler/rustc_mir/src/transform/mod.rs
@@ -38,6 +38,7 @@ pub mod match_branches;
 pub mod multiple_return_terminators;
 pub mod no_landing_pads;
 pub mod nrvo;
+pub mod prevent_early_finalization;
 pub mod promote_consts;
 pub mod remove_noop_landing_pads;
 pub mod remove_unneeded_drops;
@@ -274,6 +275,7 @@ fn mir_const<'tcx>(
             &function_item_references::FunctionItemReferences,
             // What we need to do constant evaluation.
             &simplify::SimplifyCfg::new("initial"),
+            &prevent_early_finalization::PreventEarlyFinalization,
             &rustc_peek::SanityCheck,
         ]],
     );

--- a/compiler/rustc_mir/src/transform/prevent_early_finalization.rs
+++ b/compiler/rustc_mir/src/transform/prevent_early_finalization.rs
@@ -1,0 +1,86 @@
+use crate::{transform::MirPass, util::patch::MirPatch};
+use rustc_ast::{LlvmAsmDialect, StrStyle};
+use rustc_hir as hir;
+use rustc_middle::mir::*;
+use rustc_middle::ty::{ParamEnv, TyCtxt};
+use rustc_span::symbol::{kw, sym, Symbol};
+use rustc_span::DUMMY_SP;
+
+#[derive(PartialEq)]
+pub struct PreventEarlyFinalization;
+
+impl<'tcx> MirPass<'tcx> for PreventEarlyFinalization {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        if tcx.lang_items().gc_smart_pointer_trait().is_none() {
+            return;
+        }
+        let barrier = build_asm_barrier();
+        let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
+        let gc_locals = body
+            .local_decls()
+            .iter_enumerated()
+            .filter(|(_, d)| needs_barrier(d, tcx, param_env))
+            .map(|(l, _)| l)
+            .collect::<Vec<_>>();
+
+        if gc_locals.is_empty() {
+            return;
+        }
+        // First, remove the StorageDead for each local, so that a new one can
+        // be inserted after the barrier. Usually, this is at the end of the
+        // body anyway, so it's quicker to iterate backwards over the MIR.
+        for data in body.basic_blocks_mut() {
+            for stmt in data.statements.iter_mut().rev() {
+                if let StatementKind::StorageDead(ref local) = stmt.kind {
+                    if gc_locals.contains(local) {
+                        stmt.make_nop();
+                    }
+                }
+            }
+        }
+
+        let mut patch = MirPatch::new(body);
+        // There can be many BBs which terminate with a return, so to be safe,
+        // we add an asm barrier to each one.
+        let return_blocks =
+            body.basic_blocks().iter_enumerated().filter(|(_, b)| is_return(b.terminator()));
+        for (block, data) in return_blocks {
+            for local in gc_locals.iter() {
+                let loc = Location { block, statement_index: data.statements.len() };
+                let mut asm = barrier.clone();
+                asm.inputs = Box::new([(DUMMY_SP, Operand::Copy(Place::from(*local)))]);
+                patch.add_statement(loc, StatementKind::LlvmInlineAsm(asm));
+                patch.add_statement(loc, StatementKind::StorageDead(*local));
+            }
+        }
+        patch.apply(body);
+    }
+}
+
+fn is_return<'tcx>(terminator: &Terminator<'tcx>) -> bool {
+    match terminator.kind {
+        TerminatorKind::Return => true,
+        _ => false,
+    }
+}
+
+fn needs_barrier(local: &LocalDecl<'tcx>, tcx: TyCtxt<'tcx>, param_env: ParamEnv<'tcx>) -> bool {
+    local.is_user_variable()
+        && !local.ty.is_no_finalize_modulo_regions(tcx.at(DUMMY_SP), param_env)
+        && local.ty.is_gc_smart_pointer(tcx.at(DUMMY_SP), param_env)
+}
+
+fn build_asm_barrier() -> Box<LlvmInlineAsm<'tcx>> {
+    let asm_inner = hir::LlvmInlineAsmInner {
+        asm: kw::Empty,
+        asm_str_style: StrStyle::Cooked,
+        outputs: Vec::new(),
+        inputs: vec![Symbol::intern("r")],
+        clobbers: vec![sym::memory],
+        volatile: true,
+        alignstack: false,
+        dialect: LlvmAsmDialect::Att,
+    };
+
+    Box::new(LlvmInlineAsm { asm: asm_inner, inputs: Box::new([]), outputs: Box::new([]) })
+}

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -576,6 +576,7 @@ symbols! {
         future,
         future_trait,
         gc_layout,
+        gcsp,
         ge,
         gen_future,
         gen_kill,

--- a/compiler/rustc_ty_utils/src/common_traits.rs
+++ b/compiler/rustc_ty_utils/src/common_traits.rs
@@ -30,6 +30,13 @@ fn is_no_finalize_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'
     is_item_raw(tcx, query, LangItem::NoFinalize)
 }
 
+fn is_gc_smart_pointer_raw<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+) -> bool {
+    is_item_raw(tcx, query, LangItem::GcSmartPointer)
+}
+
 fn is_item_raw<'tcx>(
     tcx: TyCtxt<'tcx>,
     query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
@@ -55,6 +62,7 @@ pub(crate) fn provide(providers: &mut ty::query::Providers) {
         is_freeze_raw,
         is_conservative_raw,
         is_no_trace_raw,
+        is_gc_smart_pointer_raw,
         is_no_finalize_raw,
         ..*providers
     };

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -26,6 +26,14 @@ pub struct Trace {
 }
 
 #[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(bootstrap), lang = "gcsp")]
+/// An internal trait which is only implemented by the `Gc` type. This exists so
+/// that the `Gc` type -- which is defined externally -- can be used as part of
+/// static analysis in the compiler. Evenually, this won't be necessary because
+/// `Gc` will be defined in the standard library.
+pub unsafe trait GcSmartPointer {}
+
+#[unstable(feature = "gc", issue = "none")]
 impl Trace {
     #[inline]
     /// Returns true if rustgc wasn't able to create a precise descriptor for

--- a/src/test/mir-opt/prevent_early_finalization.preserve_args.PreventEarlyFinalization.diff
+++ b/src/test/mir-opt/prevent_early_finalization.preserve_args.PreventEarlyFinalization.diff
@@ -1,0 +1,41 @@
+- // MIR for `preserve_args` before PreventEarlyFinalization
++ // MIR for `preserve_args` after PreventEarlyFinalization
+  
+  fn preserve_args() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/prevent_early_finalization.rs:28:20: 28:20
+      let _1: Finalizable;                 // in scope 0 at $DIR/prevent_early_finalization.rs:29:9: 29:12
+      let mut _2: Finalizable;             // in scope 0 at $DIR/prevent_early_finalization.rs:29:35: 29:51
+      let mut _3: Finalizable;             // in scope 0 at $DIR/prevent_early_finalization.rs:29:53: 29:69
+      scope 1 {
+          debug ret => _1;                 // in scope 1 at $DIR/prevent_early_finalization.rs:29:9: 29:12
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:29:9: 29:12
+          StorageLive(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:29:35: 29:51
+          _2 = Finalizable(const 123_usize); // scope 0 at $DIR/prevent_early_finalization.rs:29:35: 29:51
+          StorageLive(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:29:53: 29:69
+          _3 = Finalizable(const 456_usize); // scope 0 at $DIR/prevent_early_finalization.rs:29:53: 29:69
+          _1 = preserve_args_inner(move _2, move _3) -> [return: bb1, unwind: bb2]; // scope 0 at $DIR/prevent_early_finalization.rs:29:15: 29:70
+                                           // mir::Constant
+                                           // + span: $DIR/prevent_early_finalization.rs:29:15: 29:34
+                                           // + literal: Const { ty: fn(Finalizable, Finalizable) -> Finalizable {preserve_args_inner}, val: Value(Scalar(<ZST>)) }
+      }
+  
+      bb1: {
+          StorageDead(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:29:69: 29:70
+          StorageDead(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:29:69: 29:70
+          FakeRead(ForLet, _1);            // scope 0 at $DIR/prevent_early_finalization.rs:29:9: 29:12
+          _0 = const ();                   // scope 0 at $DIR/prevent_early_finalization.rs:28:20: 30:2
+-         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:30:1: 30:2
++         nop;                             // scope 0 at $DIR/prevent_early_finalization.rs:30:1: 30:2
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _1)]); // scope 0 at $DIR/prevent_early_finalization.rs:30:2: 30:2
++         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:30:2: 30:2
+          return;                          // scope 0 at $DIR/prevent_early_finalization.rs:30:2: 30:2
+      }
+  
+      bb2 (cleanup): {
+          resume;                          // scope 0 at $DIR/prevent_early_finalization.rs:28:1: 30:2
+      }
+  }
+  

--- a/src/test/mir-opt/prevent_early_finalization.preserve_args_inl.Inline.after.mir
+++ b/src/test/mir-opt/prevent_early_finalization.preserve_args_inl.Inline.after.mir
@@ -1,0 +1,154 @@
+// MIR for `preserve_args_inl` after Inline
+
+fn preserve_args_inl() -> Finalizable {
+    let mut _0: Finalizable;             // return place in scope 0 at $DIR/prevent_early_finalization.rs:38:27: 38:38
+    let _1: Finalizable;                 // in scope 0 at $DIR/prevent_early_finalization.rs:39:9: 39:12
+    let mut _2: Finalizable;             // in scope 0 at $DIR/prevent_early_finalization.rs:39:39: 39:55
+    let mut _3: Finalizable;             // in scope 0 at $DIR/prevent_early_finalization.rs:39:57: 39:73
+    let mut _5: usize;                   // in scope 0 at $DIR/prevent_early_finalization.rs:40:29: 40:34
+    let _6: ();                          // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _7: std::ops::Range<usize>;  // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _8: std::ops::Range<usize>;  // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _10: ();                     // in scope 0 at $DIR/prevent_early_finalization.rs:38:1: 45:2
+    let _12: ();                         // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _13: std::option::Option<usize>; // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _14: &mut std::ops::Range<usize>; // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _15: &mut std::ops::Range<usize>; // in scope 0 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+    let mut _16: isize;                  // in scope 0 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+    let mut _18: usize;                  // in scope 0 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+    let mut _19: !;                      // in scope 0 at $DIR/prevent_early_finalization.rs:41:5: 43:6
+    let _21: ();                         // in scope 0 at $DIR/prevent_early_finalization.rs:41:21: 43:6
+    let mut _22: usize;                  // in scope 0 at $DIR/prevent_early_finalization.rs:42:16: 42:17
+    scope 1 {
+        debug ret => _1;                 // in scope 1 at $DIR/prevent_early_finalization.rs:39:9: 39:12
+        let mut _4: Finalizable;         // in scope 1 at $DIR/prevent_early_finalization.rs:40:9: 40:14
+        scope 2 {
+            debug x => _4;               // in scope 2 at $DIR/prevent_early_finalization.rs:40:9: 40:14
+            let mut _9: std::ops::Range<usize>; // in scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+            scope 3 {
+                debug iter => _9;        // in scope 3 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+                let mut _11: usize;      // in scope 3 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+                scope 4 {
+                    debug __next => _11; // in scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+                    let _17: usize;      // in scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+                    let _20: usize;      // in scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+                    scope 5 {
+                        debug val => _17; // in scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+                    }
+                    scope 6 {
+                        debug i => _20;  // in scope 6 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+                    }
+                }
+            }
+            scope 8 (inlined <std::ops::Range<usize> as IntoIterator>::into_iter) { // at $DIR/prevent_early_finalization.rs:41:14: 41:20
+                debug self => _8;        // in scope 8 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+            }
+        }
+    }
+    scope 7 (inlined preserve_args_inl_inner) { // at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        debug x => _2;                   // in scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        debug y => _3;                   // in scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        let mut _23: usize;              // in scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        let mut _24: usize;              // in scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+    }
+
+    bb0: {
+        StorageLive(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:39:9: 39:12
+        StorageLive(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:39:39: 39:55
+        (_2.0: usize) = const 123_usize; // scope 0 at $DIR/prevent_early_finalization.rs:39:39: 39:55
+        StorageLive(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:39:57: 39:73
+        (_3.0: usize) = const 456_usize; // scope 0 at $DIR/prevent_early_finalization.rs:39:57: 39:73
+        StorageLive(_23);                // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        _23 = (_2.0: usize);             // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageLive(_24);                // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        _24 = (_3.0: usize);             // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        (_1.0: usize) = Add(move _23, move _24); // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageDead(_24);                // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageDead(_23);                // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:39:15: 39:74 (#397), _2)]); // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageDead(_2);                 // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:39:15: 39:74 (#400), _3)]); // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageDead(_3);                 // scope 7 at $DIR/prevent_early_finalization.rs:39:15: 39:74
+        StorageDead(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:39:73: 39:74
+        StorageDead(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:39:73: 39:74
+        StorageLive(_4);                 // scope 1 at $DIR/prevent_early_finalization.rs:40:9: 40:14
+        StorageLive(_5);                 // scope 1 at $DIR/prevent_early_finalization.rs:40:29: 40:34
+        _5 = (_1.0: usize);              // scope 1 at $DIR/prevent_early_finalization.rs:40:29: 40:34
+        (_4.0: usize) = move _5;         // scope 1 at $DIR/prevent_early_finalization.rs:40:17: 40:35
+        StorageDead(_5);                 // scope 1 at $DIR/prevent_early_finalization.rs:40:34: 40:35
+        StorageLive(_6);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_7);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_8);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        (_8.0: usize) = const 1_usize;   // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        (_8.1: usize) = const 100_usize; // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        _7 = move _8;                    // scope 8 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageDead(_8);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageLive(_9);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        _9 = move _7;                    // scope 2 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        goto -> bb1;                     // scope 3 at $DIR/prevent_early_finalization.rs:41:5: 43:6
+    }
+
+    bb1: {
+        StorageLive(_11);                // scope 3 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_12);                // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_13);                // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_14);                // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_15);                // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        _15 = &mut _9;                   // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        _14 = &mut (*_15);               // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        _13 = <std::ops::Range<usize> as Iterator>::next(move _14) -> bb2; // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+                                         // mir::Constant
+                                         // + span: $DIR/prevent_early_finalization.rs:41:14: 41:20
+                                         // + literal: Const { ty: for<'r> fn(&'r mut std::ops::Range<usize>) -> std::option::Option<<std::ops::Range<usize> as std::iter::Iterator>::Item> {<std::ops::Range<usize> as std::iter::Iterator>::next}, val: Value(Scalar(<ZST>)) }
+    }
+
+    bb2: {
+        StorageDead(_14);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        _16 = discriminant(_13);         // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        switchInt(move _16) -> [0_isize: bb3, otherwise: bb4]; // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+    }
+
+    bb3: {
+        _6 = const ();                   // scope 4 at $DIR/prevent_early_finalization.rs:41:5: 43:6
+        StorageDead(_15);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_13);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_12);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_11);                // scope 3 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        StorageDead(_9);                 // scope 2 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        StorageDead(_7);                 // scope 2 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_6);                 // scope 2 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        _0 = _4;                         // scope 2 at $DIR/prevent_early_finalization.rs:44:5: 44:6
+        llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _1)]); // scope 0 at $DIR/prevent_early_finalization.rs:45:2: 45:2
+        StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:45:2: 45:2
+        llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _4)]); // scope 0 at $DIR/prevent_early_finalization.rs:45:2: 45:2
+        StorageDead(_4);                 // scope 0 at $DIR/prevent_early_finalization.rs:45:2: 45:2
+        return;                          // scope 0 at $DIR/prevent_early_finalization.rs:45:2: 45:2
+    }
+
+    bb4: {
+        StorageLive(_17);                // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        _17 = ((_13 as Some).0: usize);  // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        StorageLive(_18);                // scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        _18 = _17;                       // scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        _11 = move _18;                  // scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        _12 = const ();                  // scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        StorageDead(_18);                // scope 5 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        StorageDead(_17);                // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        StorageDead(_15);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_13);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageDead(_12);                // scope 4 at $DIR/prevent_early_finalization.rs:41:19: 41:20
+        StorageLive(_20);                // scope 4 at $DIR/prevent_early_finalization.rs:41:9: 41:10
+        _20 = _11;                       // scope 4 at $DIR/prevent_early_finalization.rs:41:14: 41:20
+        StorageLive(_21);                // scope 6 at $DIR/prevent_early_finalization.rs:41:21: 43:6
+        StorageLive(_22);                // scope 6 at $DIR/prevent_early_finalization.rs:42:16: 42:17
+        _22 = _20;                       // scope 6 at $DIR/prevent_early_finalization.rs:42:16: 42:17
+        (_4.0: usize) = Add((_4.0: usize), move _22); // scope 6 at $DIR/prevent_early_finalization.rs:42:9: 42:17
+        StorageDead(_22);                // scope 6 at $DIR/prevent_early_finalization.rs:42:16: 42:17
+        _21 = const ();                  // scope 6 at $DIR/prevent_early_finalization.rs:41:21: 43:6
+        StorageDead(_21);                // scope 6 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        _10 = const ();                  // scope 3 at $DIR/prevent_early_finalization.rs:41:5: 43:6
+        StorageDead(_20);                // scope 4 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        StorageDead(_11);                // scope 3 at $DIR/prevent_early_finalization.rs:43:5: 43:6
+        goto -> bb1;                     // scope 3 at $DIR/prevent_early_finalization.rs:41:5: 43:6
+    }
+}

--- a/src/test/mir-opt/prevent_early_finalization.preserve_args_inner.PreventEarlyFinalization.diff
+++ b/src/test/mir-opt/prevent_early_finalization.preserve_args_inner.PreventEarlyFinalization.diff
@@ -1,0 +1,34 @@
+- // MIR for `preserve_args_inner` before PreventEarlyFinalization
++ // MIR for `preserve_args_inner` after PreventEarlyFinalization
+  
+  fn preserve_args_inner(_1: Finalizable, _2: Finalizable) -> Finalizable {
+      debug x => _1;                       // in scope 0 at $DIR/prevent_early_finalization.rs:33:24: 33:25
+      debug y => _2;                       // in scope 0 at $DIR/prevent_early_finalization.rs:33:40: 33:41
+      let mut _0: Finalizable;             // return place in scope 0 at $DIR/prevent_early_finalization.rs:33:59: 33:70
+      let mut _3: usize;                   // in scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:26
+      let mut _4: usize;                   // in scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:20
+      let mut _5: usize;                   // in scope 0 at $DIR/prevent_early_finalization.rs:34:23: 34:26
+  
+      bb0: {
+          StorageLive(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:26
+          StorageLive(_4);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:20
+          _4 = (_1.0: usize);              // scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:20
+          StorageLive(_5);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:23: 34:26
+          _5 = (_2.0: usize);              // scope 0 at $DIR/prevent_early_finalization.rs:34:23: 34:26
+          _3 = Add(move _4, move _5);      // scope 0 at $DIR/prevent_early_finalization.rs:34:17: 34:26
+          StorageDead(_5);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:25: 34:26
+          StorageDead(_4);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:25: 34:26
+          _0 = Finalizable(move _3);       // scope 0 at $DIR/prevent_early_finalization.rs:34:5: 34:27
+          StorageDead(_3);                 // scope 0 at $DIR/prevent_early_finalization.rs:34:26: 34:27
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _1)]); // scope 0 at $DIR/prevent_early_finalization.rs:35:2: 35:2
++         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:35:2: 35:2
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _2)]); // scope 0 at $DIR/prevent_early_finalization.rs:35:2: 35:2
++         StorageDead(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:35:2: 35:2
+          return;                          // scope 0 at $DIR/prevent_early_finalization.rs:35:2: 35:2
++     }
++ 
++     bb1 (cleanup): {
++         resume;                          // scope 0 at $DIR/prevent_early_finalization.rs:33:1: 35:2
+      }
+  }
+  

--- a/src/test/mir-opt/prevent_early_finalization.preserve_locals.PreventEarlyFinalization.diff
+++ b/src/test/mir-opt/prevent_early_finalization.preserve_locals.PreventEarlyFinalization.diff
@@ -1,0 +1,27 @@
+- // MIR for `preserve_locals` before PreventEarlyFinalization
++ // MIR for `preserve_locals` after PreventEarlyFinalization
+  
+  fn preserve_locals() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/prevent_early_finalization.rs:17:22: 17:22
+      let _1: Finalizable;                 // in scope 0 at $DIR/prevent_early_finalization.rs:18:9: 18:11
+      scope 1 {
+          debug gc => _1;                  // in scope 1 at $DIR/prevent_early_finalization.rs:18:9: 18:11
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:18:9: 18:11
+          _1 = Finalizable(const 123_usize); // scope 0 at $DIR/prevent_early_finalization.rs:18:14: 18:30
+          FakeRead(ForLet, _1);            // scope 0 at $DIR/prevent_early_finalization.rs:18:9: 18:11
+          _0 = const ();                   // scope 0 at $DIR/prevent_early_finalization.rs:17:22: 19:2
+-         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:19:1: 19:2
++         nop;                             // scope 0 at $DIR/prevent_early_finalization.rs:19:1: 19:2
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _1)]); // scope 0 at $DIR/prevent_early_finalization.rs:19:2: 19:2
++         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:19:2: 19:2
+          return;                          // scope 0 at $DIR/prevent_early_finalization.rs:19:2: 19:2
++     }
++ 
++     bb1 (cleanup): {
++         resume;                          // scope 0 at $DIR/prevent_early_finalization.rs:17:1: 19:2
+      }
+  }
+  

--- a/src/test/mir-opt/prevent_early_finalization.preserve_multiple_locals.PreventEarlyFinalization.diff
+++ b/src/test/mir-opt/prevent_early_finalization.preserve_multiple_locals.PreventEarlyFinalization.diff
@@ -1,0 +1,38 @@
+- // MIR for `preserve_multiple_locals` before PreventEarlyFinalization
++ // MIR for `preserve_multiple_locals` after PreventEarlyFinalization
+  
+  fn preserve_multiple_locals() -> () {
+      let mut _0: ();                      // return place in scope 0 at $DIR/prevent_early_finalization.rs:22:31: 22:31
+      let _1: Finalizable;                 // in scope 0 at $DIR/prevent_early_finalization.rs:23:9: 23:12
+      scope 1 {
+          debug gc1 => _1;                 // in scope 1 at $DIR/prevent_early_finalization.rs:23:9: 23:12
+          let _2: Finalizable;             // in scope 1 at $DIR/prevent_early_finalization.rs:24:9: 24:12
+          scope 2 {
+              debug gc2 => _2;             // in scope 2 at $DIR/prevent_early_finalization.rs:24:9: 24:12
+          }
+      }
+  
+      bb0: {
+          StorageLive(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:23:9: 23:12
+          _1 = Finalizable(const 123_usize); // scope 0 at $DIR/prevent_early_finalization.rs:23:15: 23:31
+          FakeRead(ForLet, _1);            // scope 0 at $DIR/prevent_early_finalization.rs:23:9: 23:12
+          StorageLive(_2);                 // scope 1 at $DIR/prevent_early_finalization.rs:24:9: 24:12
+          _2 = Finalizable(const 123_usize); // scope 1 at $DIR/prevent_early_finalization.rs:24:15: 24:31
+          FakeRead(ForLet, _2);            // scope 1 at $DIR/prevent_early_finalization.rs:24:9: 24:12
+          _0 = const ();                   // scope 0 at $DIR/prevent_early_finalization.rs:22:31: 25:2
+-         StorageDead(_2);                 // scope 1 at $DIR/prevent_early_finalization.rs:25:1: 25:2
+-         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:25:1: 25:2
++         nop;                             // scope 1 at $DIR/prevent_early_finalization.rs:25:1: 25:2
++         nop;                             // scope 0 at $DIR/prevent_early_finalization.rs:25:1: 25:2
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _1)]); // scope 0 at $DIR/prevent_early_finalization.rs:25:2: 25:2
++         StorageDead(_1);                 // scope 0 at $DIR/prevent_early_finalization.rs:25:2: 25:2
++         llvm_asm!(LlvmInlineAsmInner { asm: "", asm_str_style: Cooked, outputs: [], inputs: ["r"], clobbers: ["memory"], volatile: true, alignstack: false, dialect: Att } : [] : [($DIR/prevent_early_finalization.rs:1:1: 1:1 (#0), _2)]); // scope 0 at $DIR/prevent_early_finalization.rs:25:2: 25:2
++         StorageDead(_2);                 // scope 0 at $DIR/prevent_early_finalization.rs:25:2: 25:2
+          return;                          // scope 0 at $DIR/prevent_early_finalization.rs:25:2: 25:2
++     }
++ 
++     bb1 (cleanup): {
++         resume;                          // scope 0 at $DIR/prevent_early_finalization.rs:22:1: 25:2
+      }
+  }
+  

--- a/src/test/mir-opt/prevent_early_finalization.rs
+++ b/src/test/mir-opt/prevent_early_finalization.rs
@@ -1,0 +1,55 @@
+#![feature(gc)]
+#![feature(negative_impls)]
+
+use std::gc::GcSmartPointer;
+use std::gc::NoFinalize;
+
+#[derive(Clone, Copy)]
+struct Finalizable(usize);
+
+struct NonFinalizable(usize);
+
+unsafe impl GcSmartPointer for Finalizable {}
+
+impl !NoFinalize for Finalizable {}
+
+// EMIT_MIR prevent_early_finalization.preserve_locals.PreventEarlyFinalization.diff
+fn preserve_locals() {
+    let gc = Finalizable(123);
+}
+
+// EMIT_MIR prevent_early_finalization.preserve_multiple_locals.PreventEarlyFinalization.diff
+fn preserve_multiple_locals() {
+    let gc1 = Finalizable(123);
+    let gc2 = Finalizable(123);
+}
+
+// EMIT_MIR prevent_early_finalization.preserve_args.PreventEarlyFinalization.diff
+fn preserve_args() {
+    let ret = preserve_args_inner(Finalizable(123), Finalizable(456));
+}
+
+// EMIT_MIR prevent_early_finalization.preserve_args_inner.PreventEarlyFinalization.diff
+fn preserve_args_inner(x: Finalizable, y: Finalizable) -> Finalizable {
+    Finalizable(x.0 + y.0)
+}
+
+// EMIT_MIR prevent_early_finalization.preserve_args_inl.Inline.after.mir
+fn preserve_args_inl() -> Finalizable {
+    let ret = preserve_args_inl_inner(Finalizable(123), Finalizable(456));
+    let mut x = Finalizable(ret.0);
+    for i in 1..100 {
+        x.0 += i;
+    }
+    x
+}
+
+#[inline]
+fn preserve_args_inl_inner(x: Finalizable, y: Finalizable) -> Finalizable {
+    Finalizable(x.0 + y.0)
+}
+
+fn main() {
+    preserve_locals();
+    preserve_args_inl();
+}


### PR DESCRIPTION
This is a draft PR because I'm still debugging the test suite.

Currently `Gc` is defined in the libgc crate. The compiler isn't aware
of this so can't perform any specific operations on the `Gc` type. To
fix this, we introduce a `GcSmartPointer` trait which `libgc::Gc` will
implement.

This should be temporary. Eventually, the `Gc` smart pointer will be
part of the standard library. Right now though, it's convenient for
development that they are separated.