### PR TITLE
Fix broken behaviour for NoFinalize trait

### DIFF
--- a/compiler/rustc_codegen_cranelift/example/mini_core.rs
+++ b/compiler/rustc_codegen_cranelift/example/mini_core.rs
@@ -502,6 +502,8 @@ impl<T> Deref for Box<T> {
     }
 }
 
+impl<T: NoFinalize> NoFinalize for Box<T> {}
+
 #[lang = "exchange_malloc"]
 unsafe fn allocate(size: usize, _align: usize) -> *mut u8 {
     libc::malloc(size)

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -138,6 +138,7 @@ use core::cmp::Ordering;
 use core::convert::{From, TryFrom};
 use core::fmt;
 use core::future::Future;
+use core::gc::NoFinalize;
 use core::hash::{Hash, Hasher};
 #[cfg(not(no_global_oom_handling))]
 use core::iter::FromIterator;
@@ -1721,3 +1722,9 @@ impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
         (**self).size_hint()
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: NoFinalize> NoFinalize for Box<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: NoFinalize, A: Allocator> NoFinalize for Box<T, A> {}

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -3,6 +3,7 @@
 
 use core::alloc::LayoutError;
 use core::cmp;
+use core::gc::NoFinalize;
 use core::intrinsics;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::Drop;
@@ -558,3 +559,5 @@ fn alloc_guard(alloc_size: usize) -> Result<(), TryReserveError> {
 fn capacity_overflow() -> ! {
     panic!("capacity overflow");
 }
+
+impl<T: NoFinalize, A: Allocator> NoFinalize for RawVec<T, A> {}

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -58,6 +58,7 @@ use core::cmp;
 use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::fmt;
+use core::gc::NoFinalize;
 use core::hash::{Hash, Hasher};
 use core::intrinsics::{arith_offset, assume};
 use core::iter;
@@ -2710,6 +2711,12 @@ impl<T: Ord, A: Allocator> Ord for Vec<T, A> {
         Ord::cmp(&**self, &**other)
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: NoFinalize, A: Allocator> NoFinalize for Vec<T, A> {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: NoFinalize> NoFinalize for Vec<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -70,3 +70,26 @@ pub unsafe fn gc_layout<T>() -> Trace {
 
 impl<T: ?Sized> !NoTrace for *mut T {}
 impl<T: ?Sized> !NoTrace for *const T {}
+
+mod impls {
+    use super::NoFinalize;
+
+    macro_rules! impl_nofinalize {
+        ($($t:ty)*) => (
+            $(
+                #[unstable(feature = "gc", issue = "none")]
+                impl NoFinalize for $t {}
+            )*
+        )
+    }
+
+    impl_nofinalize! {
+        usize u8 u16 u32 u64 u128
+            isize i8 i16 i32 i64 i128
+            f32 f64
+            bool char
+    }
+
+    #[unstable(feature = "never_type", issue = "35121")]
+    impl NoFinalize for ! {}
+}

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -2,6 +2,7 @@
 
 use crate::cmp::Ordering::*;
 use crate::cmp::*;
+use crate::gc::NoFinalize;
 
 // macro for implementing n-ary tuple functions and operations
 macro_rules! tuple_impls {
@@ -66,6 +67,9 @@ macro_rules! tuple_impls {
                     ($({ let x: $T = Default::default(); x},)+)
                 }
             }
+
+            #[unstable(feature = "gc", issue = "none")]
+            impl<$($T:NoFinalize),+> NoFinalize for ($($T,)+) {}
         )+
     }
 }

--- a/src/test/ui/gc/needs_finalize.rs
+++ b/src/test/ui/gc/needs_finalize.rs
@@ -1,48 +1,91 @@
 // run-pass
+// ignore-tidy-linelength
 #![feature(gc)]
 
 use std::mem;
+use std::gc::NoFinalize;
 
-struct NeedsDrop;
+struct HasDrop;
 
-impl Drop for NeedsDrop {
+impl Drop for HasDrop {
     fn drop(&mut self) {}
 }
 
-struct Trivial(u8, f32);
+struct HasDropNoFinalize;
 
-struct NonTrivial(u8, NeedsDrop);
+impl Drop for HasDropNoFinalize {
+    fn drop(&mut self) {}
+}
 
-struct ExplicitNoFinalize(Trivial, NonTrivial);
+impl NoFinalize for HasDropNoFinalize {}
 
-struct NestedNoFinalize(Trivial, ExplicitNoFinalize);
+struct FinalizedContainer<T>(T);
 
-impl core::gc::NoFinalize for ExplicitNoFinalize {}
+impl<T> Drop for FinalizedContainer<T> {
+    fn drop(&mut self) {}
+}
 
 const CONST_U8: bool = mem::needs_finalizer::<u8>();
 const CONST_STRING: bool = mem::needs_finalizer::<String>();
-const CONST_TRIVIAL: bool = mem::needs_finalizer::<Trivial>();
-const CONST_NON_TRIVIAL: bool = mem::needs_finalizer::<NonTrivial>();
+const CONST_FINALIZABLE: bool = mem::needs_finalizer::<HasDrop>();
+const CONST_UNFINALIZABLE: bool = mem::needs_finalizer::<HasDropNoFinalize>();
 
 static STATIC_U8: bool = mem::needs_finalizer::<u8>();
 static STATIC_STRING: bool = mem::needs_finalizer::<String>();
-static STATIC_TRIVIAL: bool = mem::needs_finalizer::<Trivial>();
-static STATIC_NON_TRIVIAL: bool = mem::needs_finalizer::<NonTrivial>();
+static STATIC_FINALIZABLE: bool = mem::needs_finalizer::<HasDrop>();
+static STATIC_UNFINALIZABLE: bool = mem::needs_finalizer::<HasDropNoFinalize>();
 
-static STATIC_EXPLICIT_NO_FINALIZE: bool = mem::needs_finalizer::<ExplicitNoFinalize>();
-static STATIC_NESTED_NO_FINALIZE: bool = mem::needs_finalizer::<NestedNoFinalize>();
+static BOX_TRIVIAL: bool = mem::needs_finalizer::<Box<usize>>();
+static BOX_FINALIZABLE: bool = mem::needs_finalizer::<Box<HasDrop>>();
+static BOX_UNFINALIZABLE: bool = mem::needs_finalizer::<Box<HasDropNoFinalize>>();
+static BOX_TUPLE_FINALIZABLE: bool = mem::needs_finalizer::<Box<(HasDrop, HasDrop)>>();
+static BOX_TUPLE_UNFINALIZABLE: bool = mem::needs_finalizer::<Box<(HasDropNoFinalize, HasDropNoFinalize)>>();
+
+static VEC_TRIVIAL: bool = mem::needs_finalizer::<Vec<usize>>();
+static VEC_FINALIZABLE: bool = mem::needs_finalizer::<Vec<HasDrop>>();
+static VEC_UNFINALIZABLE: bool = mem::needs_finalizer::<Vec<HasDropNoFinalize>>();
+static VEC_TUPLE_UNFINALIZABLE: bool = mem::needs_finalizer::<Vec<(HasDropNoFinalize, usize)>>();
+static VEC_TUPLE_FINALIZABLE: bool = mem::needs_finalizer::<Vec<(HasDrop, HasDrop)>>();
+static VEC_TUPLE_CONTAINS_FINALIZABLE: bool = mem::needs_finalizer::<Vec<(HasDrop, usize)>>();
+
+static VEC_VEC_FINALIZABLE: bool = mem::needs_finalizer::<Vec<Vec<HasDrop>>>();
+static VEC_VEC_UNFINALIZABLE: bool = mem::needs_finalizer::<Vec<Vec<HasDropNoFinalize>>>();
+static VEC_STRING: bool = mem::needs_finalizer::<Vec<String>>();
+static VEC_BOX_FINALIZABLE: bool = mem::needs_finalizer::<Vec<Box<HasDrop>>>();
+static VEC_BOX_UNFINALIZABLE: bool = mem::needs_finalizer::<Vec<Box<HasDropNoFinalize>>>();
+
+
+static OUTER_NEEDS_FINALIZING: bool = mem::needs_finalizer::<FinalizedContainer<Vec<HasDropNoFinalize>>>();
 
 fn main() {
     assert!(!CONST_U8);
     assert!(!CONST_STRING);
-    assert!(!CONST_TRIVIAL);
-    assert!(CONST_NON_TRIVIAL);
+    assert!(CONST_FINALIZABLE);
+    assert!(!CONST_UNFINALIZABLE);
 
     assert!(!STATIC_U8);
     assert!(!STATIC_STRING);
-    assert!(!STATIC_TRIVIAL);
-    assert!(STATIC_NON_TRIVIAL);
+    assert!(STATIC_FINALIZABLE);
+    assert!(!STATIC_UNFINALIZABLE);
 
-    assert!(!STATIC_EXPLICIT_NO_FINALIZE);
-    assert!(!STATIC_NESTED_NO_FINALIZE);
+    assert!(!BOX_TRIVIAL);
+    assert!(BOX_FINALIZABLE);
+    assert!(!BOX_UNFINALIZABLE);
+    assert!(BOX_TUPLE_FINALIZABLE);
+    assert!(!BOX_TUPLE_UNFINALIZABLE);
+
+    assert!(!VEC_TRIVIAL);
+    assert!(VEC_FINALIZABLE);
+    assert!(!VEC_UNFINALIZABLE);
+    assert!(!VEC_TUPLE_UNFINALIZABLE);
+    assert!(VEC_TUPLE_FINALIZABLE);
+    assert!(VEC_TUPLE_CONTAINS_FINALIZABLE);
+
+    assert!(VEC_VEC_FINALIZABLE);
+    assert!(!VEC_VEC_UNFINALIZABLE);
+    assert!(!VEC_STRING);
+    assert!(VEC_BOX_FINALIZABLE);
+    assert!(!VEC_BOX_UNFINALIZABLE);
+
+    assert!(OUTER_NEEDS_FINALIZING);
 }


### PR DESCRIPTION
Previously `std::mem::needs_finalize<T>()` would only return `true` if
the top-level type required finalizing. This now traverses component
types correctly. See `test/ui/gc/needs_finalize.rs` for a detailed list
of which types need finalizing.

A lot of the refactoring in `needs_drop` comes from breaking changes in
upstream.