### PR TITLE
Mark `NoFinalize` as unsafe and document it.

### DIFF
--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -1724,7 +1724,7 @@ impl<S: ?Sized + Stream + Unpin> Stream for Box<S> {
 }
 
 #[unstable(feature = "gc", issue = "none")]
-impl<T: NoFinalize> NoFinalize for Box<T> {}
+unsafe impl<T: NoFinalize> NoFinalize for Box<T> {}
 
 #[unstable(feature = "gc", issue = "none")]
-impl<T: NoFinalize, A: Allocator> NoFinalize for Box<T, A> {}
+unsafe impl<T: NoFinalize, A: Allocator> NoFinalize for Box<T, A> {}

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -560,4 +560,4 @@ fn capacity_overflow() -> ! {
     panic!("capacity overflow");
 }
 
-impl<T: NoFinalize, A: Allocator> NoFinalize for RawVec<T, A> {}
+unsafe impl<T: NoFinalize, A: Allocator> NoFinalize for RawVec<T, A> {}

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2841,4 +2841,4 @@ impl From<char> for String {
 }
 
 #[unstable(feature = "gc", issue = "none")]
-impl NoFinalize for String {}
+unsafe impl NoFinalize for String {}

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -2713,10 +2713,10 @@ impl<T: Ord, A: Allocator> Ord for Vec<T, A> {
 }
 
 #[unstable(feature = "gc", issue = "none")]
-impl<T: NoFinalize, A: Allocator> NoFinalize for Vec<T, A> {}
+unsafe impl<T: NoFinalize, A: Allocator> NoFinalize for Vec<T, A> {}
 
 #[unstable(feature = "gc", issue = "none")]
-impl<T: NoFinalize> NoFinalize for Vec<T> {}
+unsafe impl<T: NoFinalize> NoFinalize for Vec<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {

--- a/library/core/src/tuple.rs
+++ b/library/core/src/tuple.rs
@@ -69,7 +69,7 @@ macro_rules! tuple_impls {
             }
 
             #[unstable(feature = "gc", issue = "none")]
-            impl<$($T:NoFinalize),+> NoFinalize for ($($T,)+) {}
+            unsafe impl<$($T:NoFinalize),+> NoFinalize for ($($T,)+) {}
         )+
     }
 }

--- a/src/test/ui/gc/needs_finalize.rs
+++ b/src/test/ui/gc/needs_finalize.rs
@@ -17,9 +17,12 @@ impl Drop for HasDropNoFinalize {
     fn drop(&mut self) {}
 }
 
-impl NoFinalize for HasDropNoFinalize {}
-
 struct FinalizedContainer<T>(T);
+struct MaybeFinalize<T>(T);
+struct ExplicitNoFinalize;
+
+unsafe impl NoFinalize for ExplicitNoFinalize {}
+unsafe impl NoFinalize for HasDropNoFinalize {}
 
 impl<T> Drop for FinalizedContainer<T> {
     fn drop(&mut self) {}
@@ -54,8 +57,10 @@ static VEC_STRING: bool = mem::needs_finalizer::<Vec<String>>();
 static VEC_BOX_FINALIZABLE: bool = mem::needs_finalizer::<Vec<Box<HasDrop>>>();
 static VEC_BOX_UNFINALIZABLE: bool = mem::needs_finalizer::<Vec<Box<HasDropNoFinalize>>>();
 
-
 static OUTER_NEEDS_FINALIZING: bool = mem::needs_finalizer::<FinalizedContainer<Vec<HasDropNoFinalize>>>();
+
+static STATIC_MAYBE_FINALIZE_NO_COMPONENTS: bool = mem::needs_finalizer::<MaybeFinalize<ExplicitNoFinalize>>();
+static STATIC_MAYBE_FINALIZE_DROP_COMPONENTS: bool = mem::needs_finalizer::<MaybeFinalize<HasDrop>>();
 
 fn main() {
     assert!(!CONST_U8);
@@ -88,4 +93,7 @@ fn main() {
     assert!(!VEC_BOX_UNFINALIZABLE);
 
     assert!(OUTER_NEEDS_FINALIZING);
+
+    assert!(!STATIC_MAYBE_FINALIZE_NO_COMPONENTS);
+    assert!(STATIC_MAYBE_FINALIZE_DROP_COMPONENTS);
 }


### PR DESCRIPTION
The `NoFinalize` trait prevents a type `T` from being finalized when its
passed to `Gc<T>`.

Now that we've settled on a preferred semantics for `NoFinalize`, the implementation here was already correct. I've tweaked it to be unsafe, added a couple more tests, and documented it.