### PR TITLE
Add rustc dependencies for containerised CI

### DIFF
--- a/.buildbot_dockerfile_debian
+++ b/.buildbot_dockerfile_debian
@@ -1,0 +1,9 @@
+FROM debian:bullseye
+ARG CI_UID
+RUN useradd -m -u ${CI_UID} ci
+RUN apt-get update && \
+    apt-get -y install build-essential curl cmake python3 git ninja-build time autoconf libtool libssl-dev
+WORKDIR /ci
+RUN chown ${CI_UID}:${CI_UID} .
+COPY --chown=${CI_UID}:${CI_UID} . .
+CMD sh -x .buildbot.sh


### PR DESCRIPTION
rustgc is now CI'd on a minimal docker container on the soft-dev build server. We need to explicitly install the rustc dependencies for each build.