### PR TITLE
Switch to building Boehm with cmake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,7 @@ dependencies = [
 name = "boehm"
 version = "0.1.0"
 dependencies = [
+ "cmake",
  "compiler_builtins",
  "core",
 ]

--- a/library/boehm/Cargo.toml
+++ b/library/boehm/Cargo.toml
@@ -8,3 +8,6 @@ license = "Apache-2.0 OR MIT"
 [dependencies]
 core = { path = "../core" }
 compiler_builtins = { version = "0.1.10", features = ['rustc-dep-of-std'] }
+
+[build-dependencies]
+cmake = "0.1"

--- a/library/boehm/src/boehm.rs
+++ b/library/boehm/src/boehm.rs
@@ -77,4 +77,8 @@ extern "C" {
     pub(crate) fn GC_allow_register_threads();
 
     pub(crate) fn GC_init();
+
+    pub(crate) fn GC_set_warn_proc(level: *mut u8);
+
+    pub(crate) fn GC_ignore_warn_proc(proc: *mut u8, word: usize);
 }

--- a/library/boehm/src/lib.rs
+++ b/library/boehm/src/lib.rs
@@ -157,4 +157,8 @@ impl GcAllocator {
     pub fn is_managed<T>(ptr: *const T) -> bool {
         unsafe { boehm::GC_is_managed(ptr as *const u8) }
     }
+
+    pub fn suppress_warnings() {
+        unsafe { boehm::GC_set_warn_proc(&boehm::GC_ignore_warn_proc as *const _ as *mut u8) };
+    }
 }

--- a/library/std/src/rt.rs
+++ b/library/std/src/rt.rs
@@ -86,6 +86,10 @@ unsafe fn init(argc: isize, argv: *const *const u8) {
         // handler next time. The is not true in the reverse case.
         GcAllocator::init();
 
+        // Boehm GC prints OOM warnings which are useful for debugging, but
+        // annoying when building the compiler in release mode.
+        GcAllocator::suppress_warnings();
+
         sys::init(argc, argv);
 
         let main_guard = sys::thread::guard::init();


### PR DESCRIPTION
Rust's build system has better support for cmake than autotools. I'm also more familiar with cmake and I find it easier to quickly switch build options when developing.