### PR TITLE
Ensure `Collectable` trait method symbols are linked

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,6 +4154,7 @@ dependencies = [
  "rustc_index",
  "rustc_macros",
  "rustc_middle",
+ "rustc_monomorphize",
  "rustc_serialize",
  "rustc_session",
  "rustc_span",

--- a/compiler/rustc_codegen_llvm/src/intrinsic.rs
+++ b/compiler/rustc_codegen_llvm/src/intrinsic.rs
@@ -335,7 +335,9 @@ impl<'ll, 'tcx> IntrinsicCallMethods<'tcx> for Builder<'_, 'll, 'tcx> {
             }
 
             sym::make_collectable => {
-                todo!();
+                // FIXME: Not yet implemented, but can't panic because this
+                // intrinsic is called during the mono tests.
+                self.const_bool(true)
             }
 
             sym::black_box => {

--- a/compiler/rustc_metadata/Cargo.toml
+++ b/compiler/rustc_metadata/Cargo.toml
@@ -27,3 +27,4 @@ rustc_ast = { path = "../rustc_ast" }
 rustc_expand = { path = "../rustc_expand" }
 rustc_span = { path = "../rustc_span" }
 rustc_session = { path = "../rustc_session" }
+rustc_monomorphize = { path = "../rustc_monomorphize" }

--- a/compiler/rustc_monomorphize/src/collectable_trait.rs
+++ b/compiler/rustc_monomorphize/src/collectable_trait.rs
@@ -1,0 +1,79 @@
+use rustc_hir::LangItem;
+use rustc_middle::mir::mono::MonoItem;
+use rustc_middle::ty::subst::GenericArg;
+use rustc_middle::ty::subst::SubstsRef;
+use rustc_middle::ty::{self, Ty, TyCtxt};
+use rustc_span::source_map::Spanned;
+use rustc_span::DUMMY_SP;
+
+use rustc_hir::def_id::DefId;
+/// Recurses through the component types of `ty` looking for types which
+/// implement the `Collectable` trait so that each
+/// `Collectable::set_collectable` method can be added to the monomorphization
+/// collector's output.
+pub(crate) fn collect_mono<'a, 'tcx>(
+    tcx: TyCtxt<'tcx>,
+    ty: Ty<'tcx>,
+    substs: SubstsRef<'tcx>,
+    output: &'a mut Vec<Spanned<MonoItem<'tcx>>>,
+) {
+    let set_col_did =
+        tcx.lang_items().require(LangItem::SetCollectable).unwrap_or_else(|e| tcx.sess.fatal(&e));
+    match ty.kind() {
+        ty::Infer(ty::FreshIntTy(_))
+        | ty::Infer(ty::FreshFloatTy(_))
+        | ty::Bool
+        | ty::Int(_)
+        | ty::Uint(_)
+        | ty::Float(_)
+        | ty::Never
+        | ty::FnDef(..)
+        | ty::FnPtr(_)
+        | ty::Char
+        | ty::GeneratorWitness(..)
+        | ty::Str => return,
+
+        ty::RawPtr(raw) => collect_mono(tcx, raw.ty, substs, output),
+        ty::Ref(_, refty, ..) => collect_mono(tcx, refty, substs, output),
+        ty::Adt(adt_def, ..) => {
+            if ty.is_collectable(tcx.at(DUMMY_SP), ty::ParamEnv::reveal_all()) {
+                let subs = tcx.mk_substs(std::iter::once::<GenericArg<'tcx>>(ty.into()));
+                let f = ty::Instance::resolve(tcx, ty::ParamEnv::reveal_all(), set_col_did, subs)
+                    .unwrap()
+                    .unwrap();
+                output.push(crate::collector::create_fn_mono_item(tcx, f, DUMMY_SP));
+            }
+
+            for v in adt_def.variants.iter() {
+                for f in v.fields.iter() {
+                    collect_mono(tcx, f.ty(tcx, substs), substs, output);
+                }
+            }
+
+            for field in adt_def.all_fields() {
+                let field_ty = tcx.type_of(field.did);
+                collect_mono(tcx, field_ty, substs, output);
+            }
+        }
+        ty::Tuple(substs) => {
+            for f in ty.tuple_fields() {
+                collect_mono(tcx, f, substs, output);
+            }
+        }
+        ty::Array(aty, ..) => collect_mono(tcx, aty, substs, output),
+        ty::Slice(sty) => collect_mono(tcx, sty, substs, output),
+        _ => return,
+    }
+}
+
+pub fn is_collectable_trait_method<'tcx>(tcx: TyCtxt<'tcx>, def_id: DefId) -> bool {
+    let col_did = tcx.lang_items().require(LangItem::Collectable);
+    if col_did.is_ok() {
+        match tcx.impl_of_method(def_id) {
+            Some(d) => tcx.trait_id_of_impl(d).map_or(false, |d| d == col_did.unwrap()),
+            None => false,
+        }
+    } else {
+        false
+    }
+}

--- a/compiler/rustc_monomorphize/src/lib.rs
+++ b/compiler/rustc_monomorphize/src/lib.rs
@@ -16,6 +16,7 @@ use rustc_middle::ty::adjustment::CustomCoerceUnsized;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, Ty, TyCtxt};
 
+pub mod collectable_trait;
 mod collector;
 mod partitioning;
 mod polymorphize;

--- a/src/test/codegen-units/item-collection/auxiliary/cgu_export_collect_trait_impl.rs
+++ b/src/test/codegen-units/item-collection/auxiliary/cgu_export_collect_trait_impl.rs
@@ -1,0 +1,70 @@
+#![crate_type = "lib"]
+#![feature(gc)]
+
+use std::gc::Collectable;
+
+pub struct S(pub usize);
+pub struct T(pub U);
+pub struct U(pub usize);
+pub struct V(pub *const X);
+pub struct X(pub usize);
+
+unsafe impl Collectable for S {
+    unsafe fn set_collectable(&self) {}
+}
+
+unsafe impl Collectable for U {
+    unsafe fn set_collectable(&self) {}
+}
+
+unsafe impl Collectable for V {
+    unsafe fn set_collectable(&self) {
+        // Explicit call of inner X's `set_collectable`
+        unsafe { (&*self.0).set_collectable() };
+    }
+}
+
+unsafe impl Collectable for X {
+    unsafe fn set_collectable(&self) {}
+}
+
+pub struct EA;
+pub struct EB;
+pub struct EC;
+pub enum E{EA(EA), EB(EB), EC(EC)}
+
+unsafe impl Collectable for EA {
+    unsafe fn set_collectable(&self) {}
+}
+
+unsafe impl Collectable for EB {
+    unsafe fn set_collectable(&self) {}
+}
+
+unsafe impl Collectable for EC {
+    unsafe fn set_collectable(&self) {}
+}
+
+pub struct TupA;
+pub struct TupB;
+
+unsafe impl Collectable for TupA {
+    unsafe fn set_collectable(&self) {}
+}
+
+unsafe impl Collectable for TupB {
+    unsafe fn set_collectable(&self) {}
+}
+
+#[derive(Copy, Clone)]
+pub struct ArrElem;
+
+unsafe impl Collectable for ArrElem {
+    unsafe fn set_collectable(&self) {}
+}
+
+pub struct SliceElem;
+
+unsafe impl Collectable for SliceElem {
+    unsafe fn set_collectable(&self) {}
+}

--- a/src/test/codegen-units/item-collection/make-collectable-intrinsic.rs
+++ b/src/test/codegen-units/item-collection/make-collectable-intrinsic.rs
@@ -1,0 +1,58 @@
+// compile-flags:-Zprint-mono-items=eager
+
+#![deny(dead_code)]
+#![feature(start)]
+#![feature(gc)]
+
+// aux-build:cgu_export_collect_trait_impl.rs
+extern crate cgu_export_collect_trait_impl;
+
+use std::mem::make_collectable;
+use cgu_export_collect_trait_impl::{E,EA,S,T,U,V,X,TupA,TupB,ArrElem,SliceElem};
+
+//~ MONO_ITEM fn start
+#[start]
+fn start(_: isize, _: *const *const u8) -> isize {
+    let s = S(123);
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::S as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<cgu_export_collect_trait_impl::S>
+    unsafe { make_collectable(&s) };
+
+    let t = T(U(123));
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::U as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<cgu_export_collect_trait_impl::T>
+    unsafe { make_collectable(&t) };
+
+    let v = V(&X(123) as *const X);
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::V as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::X as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<cgu_export_collect_trait_impl::V>
+    unsafe { make_collectable(&v) };
+
+    let e = E::EA(EA);
+    // Even though a single enum variant is instantiated, the mono collector
+    // must collect all variants since either could be possible at runtime.
+
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::EA as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::EB as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::EC as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<cgu_export_collect_trait_impl::E>
+    unsafe { make_collectable(&e) };
+
+    let tup = (TupA, TupB);
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::TupA as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::TupB as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<(cgu_export_collect_trait_impl::TupA, cgu_export_collect_trait_impl::TupB)>
+    unsafe { make_collectable(&tup) };
+
+    let array = [ArrElem; 5];
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::ArrElem as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<[cgu_export_collect_trait_impl::ArrElem; 5]>
+    unsafe { make_collectable(&array) };
+
+    let slice = &[SliceElem];
+    //~ MONO_ITEM fn <cgu_export_collect_trait_impl::SliceElem as std::gc::Collectable>::set_collectable
+    //~ MONO_ITEM fn std::mem::make_collectable::<&[cgu_export_collect_trait_impl::SliceElem; 1]>
+    unsafe { make_collectable(&slice) };
+    0
+}


### PR DESCRIPTION
After MIR lowering, rustc runs a "monomorphization collector" which determines which monomorphized function symbols should be available during the codegen phase. This can be thought of as a kind of tree shaker which walks the CFG from a predetermined set of roots looking for all instances of function calls. Those which are found are added to a "mono-list".

The purpose of `std::mem::make_collectable<T>(value: &T)` is to recurse through the fields of `value` and call `Collectable::set_collectable` on all fields whose type implements `Collectable`. However, since the body for this intrinsic is generated during codegen -- which is after the mono collector has already run -- rustc won't know that calls to `set_collectable` need to be kept in the binary.

This commit therefore patches the mono collector to do the following:

* Look for all instances of `std::mem::make_collectable<T>`.

* For each instance, recurse over the component types of `T` and add every component type's implementation of `Collectable` to the mono-list.