### PR TITLE
Prevent collections from unnecessarily finalizing elems

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -215,6 +215,7 @@ language_item_table! {
 
     Drop,                    sym::drop,                drop_trait,                 Target::Trait,          GenericRequirement::None;
     NoFinalize,              sym::no_finalize,         no_finalize_trait,          Target::Trait,          GenericRequirement::None;
+    FlzComps,                sym::flz_comps,           flz_comps_trait,            Target::Trait,          GenericRequirement::None;
 
     NoTrace,                 sym::notrace,             no_trace_trait,             Target::Trait,          GenericRequirement::None;
     Conservative,            sym::conservative,        conservative_trait,         Target::Trait,          GenericRequirement::None;

--- a/compiler/rustc_middle/src/query/mod.rs
+++ b/compiler/rustc_middle/src/query/mod.rs
@@ -1176,6 +1176,10 @@ rustc_queries! {
     query is_collectable_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
         desc { "computing whether `{}` is `Collectable`", env.value }
     }
+    /// Query backing `TyS::must_check_component_tys_for_finalizer`.
+    query must_check_component_tys_for_finalizer_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
+        desc { "computing whether `{}` contains types which might need finalizing", env.value }
+    }
     /// Query backing `TyS::needs_drop`.
     query needs_drop_raw(env: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
         desc { "computing whether `{}` needs drop", env.value }

--- a/compiler/rustc_middle/src/ty/util.rs
+++ b/compiler/rustc_middle/src/ty/util.rs
@@ -749,6 +749,14 @@ impl<'tcx> ty::TyS<'tcx> {
         tcx_at.is_collectable_raw(param_env.and(self))
     }
 
+    pub fn must_check_component_tys_for_finalizer(
+        &'tcx self,
+        tcx_at: TyCtxtAt<'tcx>,
+        param_env: ty::ParamEnv<'tcx>,
+    ) -> bool {
+        tcx_at.must_check_component_tys_for_finalizer_raw(param_env.and(self))
+    }
+
     /// Fast path helper for testing if a type is `Freeze`.
     ///
     /// Returning true means the type is known to be `Freeze`. Returning

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -655,6 +655,7 @@ symbols! {
         float_to_int_unchecked,
         floorf32,
         floorf64,
+        flz_comps,
         fmaf32,
         fmaf64,
         fmt,

--- a/compiler/rustc_ty_utils/src/common_traits.rs
+++ b/compiler/rustc_ty_utils/src/common_traits.rs
@@ -34,6 +34,13 @@ fn is_collectable_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'
     is_item_raw(tcx, query, LangItem::Collectable)
 }
 
+fn must_check_component_tys_for_finalizer_raw<'tcx>(
+    tcx: TyCtxt<'tcx>,
+    query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>,
+) -> bool {
+    is_item_raw(tcx, query, LangItem::FlzComps)
+}
+
 fn is_unpin_raw<'tcx>(tcx: TyCtxt<'tcx>, query: ty::ParamEnvAnd<'tcx, Ty<'tcx>>) -> bool {
     is_item_raw(tcx, query, LangItem::Unpin)
 }
@@ -65,6 +72,7 @@ pub(crate) fn provide(providers: &mut ty::query::Providers) {
         is_no_trace_raw,
         is_no_finalize_raw,
         is_collectable_raw,
+        must_check_component_tys_for_finalizer_raw,
         is_unpin_raw,
         ..*providers
     };

--- a/library/alloc/src/boxed.rs
+++ b/library/alloc/src/boxed.rs
@@ -139,7 +139,7 @@ use core::convert::{From, TryFrom};
 use core::fmt;
 use core::future::Future;
 use core::gc::Collectable;
-use core::gc::NoFinalize;
+use core::gc::{NoFinalize, OnlyFinalizeComponents};
 use core::hash::{Hash, Hasher};
 #[cfg(not(no_global_oom_handling))]
 use core::iter::FromIterator;
@@ -2014,7 +2014,13 @@ unsafe impl<T: NoFinalize> NoFinalize for Box<T> {}
 unsafe impl<T: NoFinalize, A: Allocator> NoFinalize for Box<T, A> {}
 
 #[unstable(feature = "gc", issue = "none")]
-unsafe impl<T, A: Allocator> Collectable for Box<T, A> {
+unsafe impl<T: ?Sized> OnlyFinalizeComponents for Box<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized, A: Allocator> OnlyFinalizeComponents for Box<T, A> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized, A: Allocator> Collectable for Box<T, A> {
     unsafe fn set_collectable(&self) {
         unsafe {
             crate::alloc::set_managed(self.0.as_ptr() as *mut u8);

--- a/library/alloc/src/raw_vec.rs
+++ b/library/alloc/src/raw_vec.rs
@@ -2,7 +2,7 @@
 
 use core::alloc::LayoutError;
 use core::cmp;
-use core::gc::NoFinalize;
+use core::gc::{NoFinalize, OnlyFinalizeComponents};
 use core::intrinsics;
 use core::mem::{self, ManuallyDrop, MaybeUninit};
 use core::ops::Drop;
@@ -481,6 +481,9 @@ unsafe impl<#[may_dangle] T, A: Allocator> Drop for RawVec<T, A> {
         }
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T, A: Allocator> OnlyFinalizeComponents for RawVec<T, A> {}
 
 // Central function for reserve error handling.
 #[cfg(not(no_global_oom_handling))]

--- a/library/alloc/src/vec/mod.rs
+++ b/library/alloc/src/vec/mod.rs
@@ -58,7 +58,7 @@ use core::cmp;
 use core::cmp::Ordering;
 use core::convert::TryFrom;
 use core::fmt;
-use core::gc::NoFinalize;
+use core::gc::{NoFinalize, OnlyFinalizeComponents};
 use core::hash::{Hash, Hasher};
 use core::intrinsics::{arith_offset, assume};
 use core::iter;
@@ -2805,6 +2805,12 @@ unsafe impl<T: NoFinalize, A: Allocator> NoFinalize for Vec<T, A> {}
 
 #[unstable(feature = "gc", issue = "none")]
 unsafe impl<T: NoFinalize> NoFinalize for Vec<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T> OnlyFinalizeComponents for Vec<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T, A: Allocator> OnlyFinalizeComponents for Vec<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<#[may_dangle] T, A: Allocator> Drop for Vec<T, A> {

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -194,6 +194,7 @@
 
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
+use crate::gc::NoFinalize;
 use crate::marker::Unsize;
 use crate::mem;
 use crate::ops::{CoerceUnsized, Deref, DerefMut};
@@ -239,6 +240,9 @@ pub struct Cell<T: ?Sized> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized> NoFinalize for Cell<T> where T: NoFinalize {}
 
 // Note that this negative impl isn't strictly necessary for correctness,
 // as `Cell` wraps `UnsafeCell`, which is itself `!Sync`.

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -26,6 +26,16 @@ pub trait Conservative {}
 #[cfg_attr(not(bootstrap), lang = "no_finalize")]
 pub unsafe trait NoFinalize {}
 
+#[cfg_attr(not(bootstrap), lang = "flz_comps")]
+/// Prevents a type from being finalized by GC if none of the component types
+/// need dropping. This can be thought of as a weaker version of `NoFinalize`.
+///
+/// # Safety
+///
+/// Unsafe because this should be used with care. Preventing drop from
+/// running can lead to surprising behaviour.
+pub unsafe trait OnlyFinalizeComponents {}
+
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(not(bootstrap), lang = "notrace")]
 pub auto trait NoTrace {}

--- a/library/core/src/option.rs
+++ b/library/core/src/option.rs
@@ -500,6 +500,7 @@
 
 #![stable(feature = "rust1", since = "1.0.0")]
 
+use crate::gc::NoFinalize;
 use crate::iter::{FromIterator, FusedIterator, TrustedLen};
 use crate::panicking::{panic, panic_str};
 use crate::pin::Pin;
@@ -2285,3 +2286,6 @@ impl<T> Option<Option<T>> {
         }
     }
 }
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: NoFinalize> NoFinalize for Option<T> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -5,6 +5,7 @@ use crate::mem;
 use crate::ops::{CoerceUnsized, DispatchFromDyn};
 
 use crate::gc::NoTrace;
+use crate::gc::OnlyFinalizeComponents;
 
 /// A wrapper around a raw non-null `*mut T` that indicates that the possessor
 /// of this wrapper owns the referent. Useful for building abstractions like
@@ -51,6 +52,9 @@ pub struct Unique<T: ?Sized> {
 /// `Unique` must enforce it.
 #[unstable(feature = "ptr_internals", issue = "none")]
 unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized> OnlyFinalizeComponents for Unique<T> {}
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they
 /// reference is unaliased. Note that this aliasing invariant is

--- a/src/test/ui/gc/needs_finalize.rs
+++ b/src/test/ui/gc/needs_finalize.rs
@@ -21,6 +21,9 @@ struct FinalizedContainer<T>(T);
 struct MaybeFinalize<T>(T);
 struct ExplicitNoFinalize;
 
+// This struct doesn't need finalizing, but it's not annoted as such.
+struct NonAnnotated(usize);
+
 unsafe impl NoFinalize for ExplicitNoFinalize {}
 unsafe impl NoFinalize for HasDropNoFinalize {}
 
@@ -63,6 +66,9 @@ static OUTER_NEEDS_FINALIZING: bool = mem::needs_finalizer::<FinalizedContainer<
 static STATIC_MAYBE_FINALIZE_NO_COMPONENTS: bool = mem::needs_finalizer::<MaybeFinalize<ExplicitNoFinalize>>();
 static STATIC_MAYBE_FINALIZE_DROP_COMPONENTS: bool = mem::needs_finalizer::<MaybeFinalize<HasDrop>>();
 
+static VEC_COLLECTABLE_NO_DROP_ELEMENT: bool = mem::needs_finalizer::<Vec<NonAnnotated>>();
+static BOX_COLLECTABLE_NO_DROP_ELEMENT: bool = mem::needs_finalizer::<Box<NonAnnotated>>();
+
 fn main() {
     assert!(!CONST_U8);
     assert!(!CONST_STRING);
@@ -98,4 +104,7 @@ fn main() {
 
     assert!(!STATIC_MAYBE_FINALIZE_NO_COMPONENTS);
     assert!(STATIC_MAYBE_FINALIZE_DROP_COMPONENTS);
+
+    assert!(!VEC_COLLECTABLE_NO_DROP_ELEMENT);
+    assert!(!BOX_COLLECTABLE_NO_DROP_ELEMENT);
 }


### PR DESCRIPTION
Collection types such as Vec<T> have drop methods which are
only necessary if T requires dropping. This can be managed partially by
implementing `NoFinalize` on `Vec<T>`:

    unsafe impl<T: NoFinalize> NoFinalize for Vec<T> {}

However, this will return true for needs_finalize if `T: !Drop` but also
doesn't implement `NoFinalize`.

To get around this, we introduce a trait which is expected only to be
used in the standard library called `OnlyFinalizeComponents`.
Implementing this trait on a type indicates to the collector that it can
ignore that type's drop method, but it must still recurse through the
type's components to see if any of them need dropping.
