### PR TITLE
Make Gc<T> implement NoFinalize

### DIFF
--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -11,7 +11,7 @@ use core::{
     ptr::{null_mut, NonNull},
 };
 
-use core::gc::NoTrace;
+use core::gc::{NoFinalize, NoTrace};
 
 use boehm::GcAllocator;
 
@@ -57,6 +57,8 @@ unsafe impl<T: Send> Send for Gc<T> {}
 unsafe impl<T: Sync + Send> Sync for Gc<T> {}
 
 impl<T: ?Sized> !NoTrace for Gc<T> {}
+
+unsafe impl<T: ?Sized + Send> NoFinalize for Gc<T> {}
 
 #[unstable(feature = "gc", issue = "none")]
 impl<T: ?Sized + Unsize<U> + Send, U: ?Sized + Send> CoerceUnsized<Gc<U>> for Gc<T> {}

--- a/src/test/ui/gc/needs_finalize.rs
+++ b/src/test/ui/gc/needs_finalize.rs
@@ -3,7 +3,7 @@
 #![feature(gc)]
 
 use std::mem;
-use std::gc::NoFinalize;
+use std::gc::{Gc, NoFinalize};
 
 struct HasDrop;
 
@@ -69,6 +69,8 @@ static STATIC_MAYBE_FINALIZE_DROP_COMPONENTS: bool = mem::needs_finalizer::<Mayb
 static VEC_COLLECTABLE_NO_DROP_ELEMENT: bool = mem::needs_finalizer::<Vec<NonAnnotated>>();
 static BOX_COLLECTABLE_NO_DROP_ELEMENT: bool = mem::needs_finalizer::<Box<NonAnnotated>>();
 
+static NESTED_GC_NO_FINALIZE: bool = mem::needs_finalizer::<Box<Gc<NonAnnotated>>>();
+
 fn main() {
     assert!(!CONST_U8);
     assert!(!CONST_STRING);
@@ -107,4 +109,5 @@ fn main() {
 
     assert!(!VEC_COLLECTABLE_NO_DROP_ELEMENT);
     assert!(!BOX_COLLECTABLE_NO_DROP_ELEMENT);
+    assert!(!NESTED_GC_NO_FINALIZE);
 }


### PR DESCRIPTION
The liveness of each Gc value is calculated independently by the
collector, so it's never necessary to call the drop method of a Gc from
another Gc's finalizer.