### PR TITLE
Allow make_collectable to be inlined

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -278,7 +278,6 @@ language_item_table! {
     ConstEvalSelect,         sym::const_eval_select,   const_eval_select,          Target::Fn,             GenericRequirement::Exact(4);
     ConstConstEvalSelect,    sym::const_eval_select_ct,const_eval_select_ct,       Target::Fn,             GenericRequirement::Exact(4);
 
-    MakeCollectableLang,     sym::make_collectable_lang, make_collectable_lang_fn,        Target::Fn,             GenericRequirement::Minimum(1);
     Start,                   sym::start,               start_fn,                   Target::Fn,             GenericRequirement::Exact(1);
 
     EhPersonality,           sym::eh_personality,      eh_personality,             Target::Fn,             GenericRequirement::None;

--- a/compiler/rustc_monomorphize/src/collector.rs
+++ b/compiler/rustc_monomorphize/src/collector.rs
@@ -202,6 +202,7 @@ use rustc_session::config::EntryFnType;
 use rustc_session::lint::builtin::LARGE_ASSIGNMENTS;
 use rustc_session::Limit;
 use rustc_span::source_map::{dummy_spanned, respan, Span, Spanned, DUMMY_SP};
+use rustc_span::symbol::sym;
 use rustc_target::abi::Size;
 use std::iter;
 use std::ops::Range;
@@ -982,9 +983,15 @@ fn visit_instance_use<'tcx>(
     }
 
     match instance.def {
-        ty::InstanceDef::Virtual(..) | ty::InstanceDef::Intrinsic(_) => {
+        ty::InstanceDef::Virtual(def_id, ..) | ty::InstanceDef::Intrinsic(def_id) => {
             if !is_direct_call {
                 bug!("{:?} being reified", instance);
+            }
+            if tcx.is_diagnostic_item(sym::make_collectable, def_id) {
+                let fn_ty = instance.ty(tcx, ty::ParamEnv::reveal_all());
+                let fn_sig = fn_ty.fn_sig(tcx);
+                let arg_ty = fn_sig.input(0).skip_binder();
+                collect_mono(tcx, arg_ty, instance.substs, output);
             }
         }
         ty::InstanceDef::DropGlue(_, None) => {
@@ -993,17 +1000,8 @@ fn visit_instance_use<'tcx>(
                 output.push(create_fn_mono_item(tcx, instance, source));
             }
         }
-        ty::InstanceDef::Item(opts) => {
-            let mk_col_did = tcx.lang_items().require(LangItem::MakeCollectableLang);
-            if mk_col_did.is_ok() && opts.did == mk_col_did.unwrap() {
-                let fn_ty = instance.ty(tcx, ty::ParamEnv::reveal_all());
-                let fn_sig = fn_ty.fn_sig(tcx);
-                let arg_ty = fn_sig.input(0).skip_binder();
-                collect_mono(tcx, arg_ty, instance.substs, output);
-            }
-            output.push(create_fn_mono_item(tcx, instance, source));
-        }
-        ty::InstanceDef::DropGlue(_, Some(_))
+        ty::InstanceDef::Item(_)
+        | ty::InstanceDef::DropGlue(_, Some(_))
         | ty::InstanceDef::VTableShim(..)
         | ty::InstanceDef::ReifyShim(..)
         | ty::InstanceDef::ClosureOnceShim { .. }

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -911,7 +911,6 @@ symbols! {
         macros_in_extern,
         main,
         make_collectable,
-        make_collectable_lang,
         manageable_contents,
         managed_boxes,
         manually_drop,

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -1492,6 +1492,7 @@ extern "rust-intrinsic" {
 
     #[unstable(feature = "gc", issue = "none")]
     #[cfg(not(bootstrap))]
+    #[rustc_diagnostic_item = "make_collectable"]
     pub fn make_collectable<T>(value: *const T);
 
     #[rustc_const_unstable(feature = "gc", issue = "none")]

--- a/library/core/src/mem/mod.rs
+++ b/library/core/src/mem/mod.rs
@@ -612,11 +612,9 @@ pub const fn needs_finalizer<T>() -> bool {
     intrinsics::needs_finalizer::<T>()
 }
 
-#[inline(never)]
 #[unstable(feature = "gc", issue = "none")]
 #[cfg(not(bootstrap))]
 #[allow(missing_docs)]
-#[cfg_attr(not(bootstrap), lang = "make_collectable_lang")]
 pub unsafe fn make_collectable<T>(value: &T) {
     intrinsics::make_collectable::<T>(value)
 }


### PR DESCRIPTION
Intrinsics can't be lang_items so to get around this we hid it behind a
no-inline core library function of the same name so that it appeared in
the monomorphisation collector.

By switching to using a rustc_diagnostic_item, we don't need to use a
lang_item anymore and we can match on the intrinsic directly. This also
means that the first `make_collectable` call can be inlined away.