### PR TITLE
Fix prevent_early_finalization pass

### DIFF
--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -71,7 +71,7 @@ mod match_branches;
 mod multiple_return_terminators;
 mod normalize_array_len;
 mod nrvo;
-// mod prevent_early_finalization;
+mod prevent_early_finalization;
 // This pass is public to allow external drivers to perform MIR cleanup
 pub mod remove_false_edges;
 mod remove_noop_landing_pads;
@@ -243,7 +243,7 @@ fn mir_const<'tcx>(
             &Lint(function_item_references::FunctionItemReferences),
             // What we need to do constant evaluation.
             &simplify::SimplifyCfg::new("initial"),
-            // &prevent_early_finalization::PreventEarlyFinalization,
+            &prevent_early_finalization::PreventEarlyFinalization,
             &rustc_peek::SanityCheck, // Just a lint
             &marker::PhaseChange(MirPhase::Const),
         ],

--- a/compiler/rustc_mir_transform/src/prevent_early_finalization.rs
+++ b/compiler/rustc_mir_transform/src/prevent_early_finalization.rs
@@ -1,10 +1,8 @@
 use crate::MirPass;
-use rustc_ast::{LlvmAsmDialect, StrStyle};
-use rustc_hir as hir;
 use rustc_middle::mir::patch::MirPatch;
 use rustc_middle::mir::*;
 use rustc_middle::ty::{self, ParamEnv, TyCtxt};
-use rustc_span::symbol::{kw, sym, Symbol};
+use rustc_span::symbol::sym;
 use rustc_span::DUMMY_SP;
 
 #[derive(PartialEq)]
@@ -15,44 +13,61 @@ impl<'tcx> MirPass<'tcx> for PreventEarlyFinalization {
         if tcx.lang_items().gc_type().is_none() {
             return;
         }
-        let barrier = build_asm_barrier();
+
         let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
         let gc_locals = body
             .local_decls()
             .iter_enumerated()
-            .filter(|(_, d)| needs_barrier(d, tcx, param_env))
+            .filter(|(_, d)| needs_black_box(d, tcx, param_env))
             .map(|(l, _)| l)
             .collect::<Vec<_>>();
 
         if gc_locals.is_empty() {
             return;
         }
-        // First, remove the StorageDead for each local, so that a new one can
-        // be inserted after the barrier. Usually, this is at the end of the
-        // body anyway, so it's quicker to iterate backwards over the MIR.
-        for data in body.basic_blocks_mut() {
-            for stmt in data.statements.iter_mut().rev() {
-                if let StatementKind::StorageDead(ref local) = stmt.kind {
-                    if gc_locals.contains(local) {
-                        stmt.make_nop();
-                    }
-                }
-            }
-        }
 
         let mut patch = MirPatch::new(body);
+        let operand = Operand::function_handle(
+            tcx,
+            tcx.get_diagnostic_item(sym::black_box).unwrap(),
+            ty::List::empty(),
+            DUMMY_SP,
+        );
+
         // There can be many BBs which terminate with a return, so to be safe,
-        // we add an asm barrier to each one.
+        // we add a black box to each one.
         let return_blocks =
             body.basic_blocks().iter_enumerated().filter(|(_, b)| is_return(b.terminator()));
-        for (block, data) in return_blocks {
-            for local in gc_locals.iter() {
-                let loc = Location { block, statement_index: data.statements.len() };
-                let mut asm = barrier.clone();
-                asm.inputs = Box::new([(DUMMY_SP, Operand::Copy(Place::from(*local)))]);
-                // patch.add_statement(loc, StatementKind::LlvmInlineAsm(asm));
-                patch.add_statement(loc, StatementKind::StorageDead(*local));
+        for (ret_bb, ret_bb_data) in return_blocks {
+            let return_terminator = ret_bb_data.terminator().clone();
+            let mut successor = patch.new_block(BasicBlockData {
+                statements: vec![],
+                terminator: Some(return_terminator),
+                is_cleanup: false,
+            });
+
+            for keep_alive in gc_locals.iter() {
+                let unit_temp = Place::from(patch.new_temp(tcx.mk_unit(), DUMMY_SP));
+                let black_box_call = TerminatorKind::Call {
+                    func: operand.clone(),
+                    args: vec![Operand::Move(Place::from(*keep_alive))],
+                    destination: unit_temp,
+                    target: Some(successor),
+                    cleanup: None,
+                    from_hir_call: false,
+                    fn_span: DUMMY_SP,
+                };
+
+                successor = patch.new_block(BasicBlockData {
+                    statements: vec![],
+                    terminator: Some(Terminator {
+                        source_info: SourceInfo::outermost(DUMMY_SP),
+                        kind: black_box_call,
+                    }),
+                    is_cleanup: false,
+                });
             }
+            patch.patch_terminator(ret_bb, TerminatorKind::Goto { target: successor });
         }
         patch.apply(body);
     }
@@ -65,7 +80,7 @@ fn is_return<'tcx>(terminator: &Terminator<'tcx>) -> bool {
     }
 }
 
-fn needs_barrier<'tcx>(
+fn needs_black_box<'tcx>(
     local: &LocalDecl<'tcx>,
     tcx: TyCtxt<'tcx>,
     param_env: ParamEnv<'tcx>,
@@ -87,19 +102,4 @@ fn needs_barrier<'tcx>(
     }
 
     return false;
-}
-
-fn build_asm_barrier<'tcx>() -> Box<LlvmInlineAsm<'tcx>> {
-    let asm_inner = hir::LlvmInlineAsmInner {
-        asm: kw::Empty,
-        asm_str_style: StrStyle::Cooked,
-        outputs: Vec::new(),
-        inputs: vec![Symbol::intern("r")],
-        clobbers: vec![sym::memory],
-        volatile: true,
-        alignstack: false,
-        dialect: LlvmAsmDialect::Att,
-    };
-
-    Box::new(LlvmInlineAsm { asm: asm_inner, inputs: Box::new([]), outputs: Box::new([]) })
 }

--- a/library/core/src/intrinsics.rs
+++ b/library/core/src/intrinsics.rs
@@ -2314,6 +2314,7 @@ extern "rust-intrinsic" {
     ///
     /// [`std::hint::black_box`]: crate::hint::black_box
     #[rustc_const_unstable(feature = "const_black_box", issue = "none")]
+    #[rustc_diagnostic_item = "black_box"]
     pub fn black_box<T>(dummy: T) -> T;
 
     /// `ptr` must point to a vtable.


### PR DESCRIPTION
This relied on patching an llvm_asm statement to the end of a MIR block.
llvm_asm is now deprecated, so instead we patch a call to the black_box
intrinsic, which does the same thing.