### PR TITLE
Disable atomic allocation

### DIFF
--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -205,17 +205,7 @@ struct GcBox<T: ?Sized>(ManuallyDrop<T>);
 impl<T> GcBox<T> {
     fn new(value: T) -> *mut GcBox<T> {
         let layout = Layout::new::<T>();
-
-        #[cfg(bootstrap)]
         let ptr = ALLOCATOR.allocate(layout).unwrap().as_ptr() as *mut GcBox<T>;
-
-        #[cfg(not(bootstrap))]
-        let ptr = if core::gc::needs_tracing::<T>() {
-            ALLOCATOR.allocate(layout).unwrap().as_ptr()
-        } else {
-            ALLOCATOR.alloc_untraceable(layout).unwrap().as_ptr()
-        } as *mut GcBox<T>;
-
         let gcbox = GcBox(ManuallyDrop::new(value));
 
         unsafe {


### PR DESCRIPTION
The introduction of new allocation methods from dynamic allocation
switching support in Boehm seems to have caused `allocate_untraceable`
to be sometimes erroneously be used on blocks which contain pointers.

We should fall back to allocating blocks conservatively while I
investigate it.