### PR TITLE
Add MIR pass to verify finalizers can be run safely

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -1,0 +1,87 @@
+use crate::MirPass;
+use rustc_middle::mir::*;
+use rustc_middle::ty::subst::InternalSubsts;
+use rustc_middle::ty::{self, TyCtxt};
+use rustc_span::symbol::sym;
+use rustc_span::Span;
+use rustc_trait_selection::infer::InferCtxtExt;
+use rustc_trait_selection::infer::TyCtxtInferExt;
+#[derive(PartialEq)]
+pub struct CheckFinalizers;
+
+impl<'tcx> MirPass<'tcx> for CheckFinalizers {
+    fn run_pass(&self, tcx: TyCtxt<'tcx>, body: &mut Body<'tcx>) {
+        let ctor = tcx.get_diagnostic_item(sym::gc_ctor);
+
+        if ctor.is_none() {
+            return;
+        }
+
+        let ctor_did = ctor.unwrap();
+        let param_env = tcx.param_env_reveal_all_normalized(body.source.def_id());
+
+        for block in body.basic_blocks() {
+            match &block.terminator {
+                Some(Terminator { kind: TerminatorKind::Call { func, args, .. }, source_info }) => {
+                    let func_ty = func.ty(body, tcx);
+                    if let ty::FnDef(fn_did, _) = func_ty.kind() {
+                        if *fn_did == ctor_did {
+                            let arg_ty = args[0].ty(body, tcx);
+                            if !arg_ty.needs_finalizer(tcx, param_env) {
+                                return;
+                            }
+
+                            let (is_send, is_sync) = tcx.infer_ctxt().enter(|infcx| {
+                                let send = tcx.get_diagnostic_item(sym::Send).map(|t| {
+                                    infcx
+                                        .type_implements_trait(
+                                            t,
+                                            arg_ty,
+                                            InternalSubsts::empty(),
+                                            param_env,
+                                        )
+                                        .may_apply()
+                                }) == Some(true);
+
+                                let sync = tcx.get_diagnostic_item(sym::Sync).map(|t| {
+                                    infcx
+                                        .type_implements_trait(
+                                            t,
+                                            arg_ty,
+                                            InternalSubsts::empty(),
+                                            param_env,
+                                        )
+                                        .may_apply()
+                                }) == Some(true);
+                                (send, sync)
+                            });
+                            if !is_send {
+                                emit_err(tcx, body, source_info.span, &args[0], "Send");
+                            }
+                            if !is_sync {
+                                emit_err(tcx, body, source_info.span, &args[0], "Sync");
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn emit_err<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, fun: Span, arg: &Operand<'tcx>, t: &str) {
+    let arg_sp = match arg {
+        Operand::Copy(place) | Operand::Move(place) => {
+            body.local_decls()[place.local].source_info.span
+        }
+        Operand::Constant(con) => con.span,
+    };
+    let snippet = tcx.sess.source_map().span_to_snippet(arg_sp).unwrap();
+    let mut err =
+        tcx.sess.struct_span_err(arg_sp, format!("`{}` cannot be safely finalized.", snippet));
+    err.span_label(arg_sp, "has a drop method which cannot be safely finalized.");
+    err.span_label(fun, format!("`Gc::new` requires that it implements the `{}` trait.", t));
+    err.help(format!("`Gc` runs finalizers on a separate thread, so `{}` must implement `{}` in order to be safely dropped", snippet, t));
+    err.emit();
+}

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -41,6 +41,7 @@ mod add_call_guards;
 mod add_moves_for_packed_drops;
 mod add_retag;
 mod check_const_item_mutation;
+mod check_finalizers;
 mod check_packed_ref;
 pub mod check_unsafety;
 // This pass is public to allow external drivers to perform MIR cleanup
@@ -244,6 +245,7 @@ fn mir_const<'tcx>(
             // What we need to do constant evaluation.
             &simplify::SimplifyCfg::new("initial"),
             &prevent_early_finalization::PreventEarlyFinalization,
+            &check_finalizers::CheckFinalizers,
             &rustc_peek::SanityCheck, // Just a lint
             &marker::PhaseChange(MirPhase::Const),
         ],

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -765,6 +765,7 @@ symbols! {
         future,
         future_trait,
         gc,
+        gc_ctor,
         gc_layout,
         gdb_script_file,
         ge,

--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -73,6 +73,7 @@ struct GcBox<T: ?Sized>(ManuallyDrop<T>);
 /// See the [module-level documentation](./index.html) for more details.
 #[unstable(feature = "gc", issue = "none")]
 #[cfg_attr(all(not(bootstrap), not(test)), lang = "gc")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "gc")]
 pub struct Gc<T: ?Sized> {
     ptr: NonNull<GcBox<T>>,
     _phantom: PhantomData<T>,
@@ -120,7 +121,7 @@ impl<T: ?Sized> Gc<T> {
     }
 }
 
-impl<T: Send + Sync> Gc<T> {
+impl<T> Gc<T> {
     /// Constructs a new `Gc<T>`.
     ///
     /// # Examples
@@ -133,6 +134,7 @@ impl<T: Send + Sync> Gc<T> {
     /// ```
     #[cfg(not(no_global_oom_handling))]
     #[unstable(feature = "gc", issue = "none")]
+    #[cfg_attr(not(test), rustc_diagnostic_item = "gc_ctor")]
     pub fn new(value: T) -> Self {
         let mut gc = unsafe { Self::new_internal(value) };
         gc.register_finalizer();

--- a/src/test/ui/gc/check_finalizers.rs
+++ b/src/test/ui/gc/check_finalizers.rs
@@ -1,0 +1,17 @@
+// check-fail
+#![feature(gc)]
+
+use std::gc::Gc;
+
+struct Hello(*mut u8);
+
+impl Drop for Hello {
+    fn drop(&mut self) {
+        println!("Dropping Hello");
+    }
+}
+
+fn main() {
+    Gc::new(Hello(123 as *mut u8)); //~ ERROR `Hello(123 as *mut u8)` cannot be safely finalized.
+    //~| ERROR `Hello(123 as *mut u8)` cannot be safely finalized.
+}

--- a/src/test/ui/gc/check_finalizers.stderr
+++ b/src/test/ui/gc/check_finalizers.stderr
@@ -1,0 +1,24 @@
+error: `Hello(123 as *mut u8)` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:15:13
+   |
+LL |     Gc::new(Hello(123 as *mut u8));
+   |     --------^^^^^^^^^^^^^^^^^^^^^-
+   |     |       |
+   |     |       has a drop method which cannot be safely finalized.
+   |     `Gc::new` requires that it implements the `Send` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Send` in order to be safely dropped
+
+error: `Hello(123 as *mut u8)` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:15:13
+   |
+LL |     Gc::new(Hello(123 as *mut u8));
+   |     --------^^^^^^^^^^^^^^^^^^^^^-
+   |     |       |
+   |     |       has a drop method which cannot be safely finalized.
+   |     `Gc::new` requires that it implements the `Sync` trait.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Sync` in order to be safely dropped
+
+error: aborting due to 2 previous errors
+


### PR DESCRIPTION
The GC runs finalizers on a separate thread, which means that values with drop implementations must be `Send` + `Sync`. This puts a big restriction on which types can be passed to `Gc::new`.

There are cases where Gc does not need to run finalizers for a value because a) it doesn't have a drop method, or b) the drop call is removed by finalizer optimisation. However, these values are still prevented from being passed to Gc new because there's no way to check that `T: Send + Sync + !Drop` in the type system.

This pass allows such values to be constructed with `Gc::new` by removing the `T: Send + Sync` bound on `Gc::new`, but then uses a MIR pass later in the pipeline to check that if those values require dropping, they implement `Send + Sync`.

We could allow more legal types to pass this check by moving it further down into the codegen phase which happens after monomophisation, but this would prevent it from running with a `cargo check`, so on balance I think this is the right place. Values which violate this rule will lead to a compiler error like below:

```
error: `Hello(123 as *mut u8)` cannot be safely finalized.
  --> src/main.rs:14:13
   |
14 |     Gc::new(Hello(123 as *mut u8));
   |     --------^^^^^^^^^^^^^^^^^^^^^-
   |     |       |
   |     |       has a drop method which cannot be safely finalized.
   |     `Gc::new` requires that it implements the `Send` trait.
   |
   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Send` in order to be safely dropped

error: `Hello(123 as *mut u8)` cannot be safely finalized.
  --> src/main.rs:14:13
   |
14 |     Gc::new(Hello(123 as *mut u8));
   |     --------^^^^^^^^^^^^^^^^^^^^^-
   |     |       |
   |     |       has a drop method which cannot be safely finalized.
   |     `Gc::new` requires that it implements the `Sync` trait.
   |
   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Sync` in order to be safely dropped
```