### PR TITLE
Add `FinalizerSafe` auto trait to enforce safe drop impls for `Gc` values

### DIFF
--- a/compiler/rustc_mir_transform/src/check_finalizers.rs
+++ b/compiler/rustc_mir_transform/src/check_finalizers.rs
@@ -1,11 +1,14 @@
 use crate::MirPass;
+use rustc_hir::lang_items::LangItem;
+use rustc_middle::mir::visit::PlaceContext;
+use rustc_middle::mir::visit::Visitor;
 use rustc_middle::mir::*;
 use rustc_middle::ty::subst::InternalSubsts;
-use rustc_middle::ty::{self, TyCtxt};
+use rustc_middle::ty::{self, ParamEnv, Subst, Ty, TyCtxt};
 use rustc_span::symbol::sym;
-use rustc_span::Span;
-use rustc_trait_selection::infer::InferCtxtExt;
-use rustc_trait_selection::infer::TyCtxtInferExt;
+use rustc_span::{Span, DUMMY_SP};
+use rustc_trait_selection::infer::{InferCtxtExt, TyCtxtInferExt};
+
 #[derive(PartialEq)]
 pub struct CheckFinalizers;
 
@@ -24,43 +27,18 @@ impl<'tcx> MirPass<'tcx> for CheckFinalizers {
             match &block.terminator {
                 Some(Terminator { kind: TerminatorKind::Call { func, args, .. }, source_info }) => {
                     let func_ty = func.ty(body, tcx);
-                    if let ty::FnDef(fn_did, _) = func_ty.kind() {
+                    if let ty::FnDef(fn_did, ..) = func_ty.kind() {
                         if *fn_did == ctor_did {
+                            let arg = match &args[0] {
+                                Operand::Copy(place) | Operand::Move(place) => {
+                                    body.local_decls()[place.local].source_info.span
+                                }
+                                Operand::Constant(con) => con.span,
+                            };
                             let arg_ty = args[0].ty(body, tcx);
-                            if !arg_ty.needs_finalizer(tcx, param_env) {
-                                return;
-                            }
-
-                            let (is_send, is_sync) = tcx.infer_ctxt().enter(|infcx| {
-                                let send = tcx.get_diagnostic_item(sym::Send).map(|t| {
-                                    infcx
-                                        .type_implements_trait(
-                                            t,
-                                            arg_ty,
-                                            InternalSubsts::empty(),
-                                            param_env,
-                                        )
-                                        .may_apply()
-                                }) == Some(true);
-
-                                let sync = tcx.get_diagnostic_item(sym::Sync).map(|t| {
-                                    infcx
-                                        .type_implements_trait(
-                                            t,
-                                            arg_ty,
-                                            InternalSubsts::empty(),
-                                            param_env,
-                                        )
-                                        .may_apply()
-                                }) == Some(true);
-                                (send, sync)
-                            });
-                            if !is_send {
-                                emit_err(tcx, body, source_info.span, &args[0], "Send");
-                            }
-                            if !is_sync {
-                                emit_err(tcx, body, source_info.span, &args[0], "Sync");
-                            }
+                            let mut finalizer_cx =
+                                FinalizationCtxt { ctor: source_info.span, arg, tcx, param_env };
+                            finalizer_cx.check(arg_ty);
                         }
                     }
                 }
@@ -70,18 +48,224 @@ impl<'tcx> MirPass<'tcx> for CheckFinalizers {
     }
 }
 
-fn emit_err<'tcx>(tcx: TyCtxt<'tcx>, body: &Body<'tcx>, fun: Span, arg: &Operand<'tcx>, t: &str) {
-    let arg_sp = match arg {
-        Operand::Copy(place) | Operand::Move(place) => {
-            body.local_decls()[place.local].source_info.span
+struct FinalizationCtxt<'tcx> {
+    ctor: Span,
+    arg: Span,
+    tcx: TyCtxt<'tcx>,
+    param_env: ParamEnv<'tcx>,
+}
+
+impl<'tcx> FinalizationCtxt<'tcx> {
+    fn check(&mut self, ty: Ty<'tcx>) {
+        if self.is_finalizer_safe(ty) || self.is_no_finalize(ty) {
+            return;
         }
-        Operand::Constant(con) => con.span,
-    };
-    let snippet = tcx.sess.source_map().span_to_snippet(arg_sp).unwrap();
-    let mut err =
-        tcx.sess.struct_span_err(arg_sp, format!("`{}` cannot be safely finalized.", snippet));
-    err.span_label(arg_sp, "has a drop method which cannot be safely finalized.");
-    err.span_label(fun, format!("`Gc::new` requires that it implements the `{}` trait.", t));
-    err.help(format!("`Gc` runs finalizers on a separate thread, so `{}` must implement `{}` in order to be safely dropped", snippet, t));
-    err.emit();
+
+        // We must now recurse through the `Ty`'s component types and search for
+        // all the `Drop` impls. If we find any, we have to check that there are
+        // no unsound projections into fields in their drop method body. More
+        // specifically: if one of the drop methods dereferences a field which
+        // is !FinalizerSafe, we must throw an error.
+        match ty.kind() {
+            ty::Infer(ty::FreshIntTy(_))
+            | ty::Infer(ty::FreshFloatTy(_))
+            | ty::Bool
+            | ty::Int(_)
+            | ty::Uint(_)
+            | ty::Float(_)
+            | ty::Never
+            | ty::FnDef(..)
+            | ty::FnPtr(_)
+            | ty::Char
+            | ty::GeneratorWitness(..)
+            | ty::RawPtr(_)
+            | ty::Ref(..)
+            | ty::Str
+            | ty::Foreign(..) => {
+                // None of these types can implement Drop.
+                return;
+            }
+            ty::Dynamic(..) | ty::Error(..) => {
+                // Dropping a trait object uses a virtual call, so we can't
+                // work out which drop method to look at compile-time. This
+                // means we must be more conservative and bail with an error
+                // here, even if the drop impl itself would have been safe.
+                self.emit_err();
+            }
+            ty::Slice(ty) => self.check(*ty),
+            ty::Array(elem_ty, ..) => {
+                self.check(*elem_ty);
+            }
+            ty::Tuple(fields) => {
+                // Each tuple field must be individually checked for a `Drop`
+                // impl.
+                fields.iter().for_each(|f_ty| self.check(f_ty));
+            }
+            ty::Adt(def, substs) if !self.is_copy(ty) => {
+                if def.has_dtor(self.tcx) {
+                    if def.is_box() {
+                        // This is a special case because Box has an empty drop
+                        // method which is filled in later by the compiler.
+                        self.emit_err();
+                    }
+
+                    let drop_trait = self.tcx.require_lang_item(LangItem::Drop, None);
+                    let drop_fn = self.tcx.associated_item_def_ids(drop_trait)[0];
+                    let substs = self.tcx.mk_substs_trait(ty, substs);
+                    let instance = ty::Instance::resolve(self.tcx, self.param_env, drop_fn, substs)
+                        .unwrap()
+                        .unwrap();
+                    let mir = self.tcx.instance_mir(instance.def);
+                    let mut checker = ProjectionChecker { cx: self, body: mir };
+                    checker.visit_body(&mir);
+                }
+
+                for field in def.all_fields() {
+                    let field_ty = self.tcx.bound_type_of(field.did).subst(self.tcx, substs);
+                    self.check(field_ty);
+                }
+            }
+            _ => (),
+        }
+    }
+
+    fn is_finalizer_safe(&self, ty: Ty<'tcx>) -> bool {
+        self.tcx.infer_ctxt().enter(|infcx| {
+            self.tcx.get_diagnostic_item(sym::FinalizerSafe).map(|t| {
+                infcx
+                    .type_implements_trait(t, ty, InternalSubsts::empty(), self.param_env)
+                    .may_apply()
+            }) == Some(true)
+        })
+    }
+
+    fn is_no_finalize(&self, ty: Ty<'tcx>) -> bool {
+        ty.is_no_finalize_modulo_regions(self.tcx.at(DUMMY_SP), self.param_env)
+    }
+
+    fn is_copy(&self, ty: Ty<'tcx>) -> bool {
+        ty.is_copy_modulo_regions(self.tcx.at(DUMMY_SP), self.param_env)
+    }
+
+    fn is_gc(&self, ty: Ty<'tcx>) -> bool {
+        if let ty::Adt(def, ..) = ty.kind() {
+            if def.did() == self.tcx.get_diagnostic_item(sym::gc).unwrap() {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    fn emit_err(&self) {
+        let arg = self.tcx.sess.source_map().span_to_snippet(self.arg).unwrap();
+        let mut err = self
+            .tcx
+            .sess
+            .struct_span_err(self.arg, format!("`{arg}` cannot be safely finalized.",));
+        err.span_label(self.arg, "has a drop method which cannot be safely finalized.");
+        err.span_label(
+            self.ctor,
+            format!("`Gc::new` requires that it implements the `FinalizeSafe` trait.",),
+        );
+        err.help(format!("`Gc` runs finalizers on a separate thread, so `{arg}` must implement `FinalizeSafe` in order to be safely dropped.",));
+        err.emit();
+    }
+}
+
+struct ProjectionChecker<'a, 'tcx> {
+    cx: &'a FinalizationCtxt<'tcx>,
+    body: &'a Body<'tcx>,
+}
+
+impl<'a, 'tcx> ProjectionChecker<'a, 'tcx> {
+    fn emit_err(&self, ty: Ty<'tcx>, span: Span) {
+        let arg = self.cx.tcx.sess.source_map().span_to_snippet(self.cx.arg).unwrap();
+        let mut err = self
+            .cx
+            .tcx
+            .sess
+            .struct_span_err(self.cx.arg, format!("`{arg}` cannot be safely finalized.",));
+        if self.cx.is_gc(ty) {
+            err.span_label(self.cx.arg, "has a drop method which cannot be safely finalized.");
+            err.span_label(span, "caused by the expression here in `fn drop(&mut)` because");
+            err.span_label(span, "it uses another `Gc` type.");
+            err.help("`Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.");
+        } else {
+            err.span_label(self.cx.arg, "has a drop method which cannot be safely finalized.");
+            err.span_label(span, "caused by the expression in `fn drop(&mut)` here because");
+            err.span_label(span, "it uses a type which is not safe to use in a finalizer.");
+            err.help("`Gc` runs finalizers on a separate thread, so drop methods\nmust only use values whose types implement `Send + Sync` or `FinalizerSafe`.");
+        }
+        err.emit();
+    }
+}
+
+impl<'a, 'tcx> Visitor<'tcx> for ProjectionChecker<'a, 'tcx> {
+    fn visit_projection(
+        &mut self,
+        place_ref: PlaceRef<'tcx>,
+        context: PlaceContext,
+        location: Location,
+    ) {
+        for (_, proj) in place_ref.iter_projections() {
+            match proj {
+                ProjectionElem::Field(_, ty) => {
+                    if !self.cx.is_finalizer_safe(ty) {
+                        let span = self.body.source_info(location).span;
+                        self.emit_err(ty, span);
+                    }
+                }
+                _ => (),
+            }
+        }
+        self.super_projection(place_ref, context, location);
+    }
+
+    fn visit_terminator(&mut self, terminator: &Terminator<'tcx>, location: Location) {
+        if let TerminatorKind::Call { ref args, .. } = terminator.kind {
+            for caller_arg in self.body.args_iter() {
+                let recv_ty = self.body.local_decls()[caller_arg].ty;
+                for arg in args.iter() {
+                    let arg_ty = arg.ty(self.body, self.cx.tcx);
+                    if arg_ty == recv_ty {
+                        // Currently, we do not recurse into function calls
+                        // to see whether they access `!FinalizerSafe`
+                        // fields, so we must throw an error in `drop`
+                        // methods which call other functions and pass
+                        // `self` as an argument.
+                        //
+                        // Here, we throw an error if `drop(&mut self)`
+                        // calls a function with an argument that has the
+                        // same type as the drop receiver (e.g. foo(x:
+                        // &Self)). This approximation will always prevent
+                        // unsound `drop` methods, however, it is overly
+                        // conservative and will prevent correct examples
+                        // like below from compiling:
+                        //
+                        // ```
+                        // fn drop(&mut self) {
+                        //   let x = Self { ... };
+                        //   x.foo();
+                        // }
+                        // ```
+                        //
+                        // This example is sound, because `x` is a local
+                        // that was instantiated on the finalizer thread, so
+                        // its fields are always safe to access from inside
+                        // this drop method.
+                        //
+                        // However, this will not compile, because the
+                        // receiver for `x.foo()` is the same type as the
+                        // `self` reference. To fix this, we would need to
+                        // do a def-use analysis on the self reference to
+                        // find every MIR local which refers to it that ends
+                        // up being passed to a call terminator. This is not
+                        // trivial to do at the moment.
+                        let span = self.body.source_info(location).span;
+                        self.emit_err(arg_ty, span);
+                    }
+                }
+            }
+        }
+    }
 }

--- a/compiler/rustc_mir_transform/src/lib.rs
+++ b/compiler/rustc_mir_transform/src/lib.rs
@@ -245,7 +245,6 @@ fn mir_const<'tcx>(
             // What we need to do constant evaluation.
             &simplify::SimplifyCfg::new("initial"),
             &prevent_early_finalization::PreventEarlyFinalization,
-            &check_finalizers::CheckFinalizers,
             &rustc_peek::SanityCheck, // Just a lint
             &marker::PhaseChange(MirPhase::Const),
         ],
@@ -287,6 +286,7 @@ fn mir_promoted<'tcx>(
             &promote_pass,
             &simplify::SimplifyCfg::new("promote-consts"),
             &coverage::InstrumentCoverage,
+            &check_finalizers::CheckFinalizers,
         ],
     );
 

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -189,6 +189,7 @@ symbols! {
         Error,
         File,
         FileType,
+        FinalizerSafe,
         Fn,
         FnMut,
         FnOnce,

--- a/library/alloc/src/collections/btree/borrow.rs
+++ b/library/alloc/src/collections/btree/borrow.rs
@@ -18,6 +18,7 @@ pub struct DormantMutRef<'a, T> {
 
 unsafe impl<'a, T> Sync for DormantMutRef<'a, T> where &'a mut T: Sync {}
 unsafe impl<'a, T> Send for DormantMutRef<'a, T> where &'a mut T: Send {}
+unsafe impl<'a, T> FinalizerSafe for DormantMutRef<'a, T> where &'a mut T: FinalizerSafe {}
 
 impl<'a, T> DormantMutRef<'a, T> {
     /// Capture a unique borrow, and immediately reborrow it. For the compiler,

--- a/library/alloc/src/collections/btree/node.rs
+++ b/library/alloc/src/collections/btree/node.rs
@@ -205,6 +205,10 @@ impl<'a, K: 'a, V: 'a, Type> Clone for NodeRef<marker::Immut<'a>, K, V, Type> {
 }
 
 unsafe impl<BorrowType, K: Sync, V: Sync, Type> Sync for NodeRef<BorrowType, K, V, Type> {}
+unsafe impl<BorrowType, K: FinalizerSafe, V: FinalizerSafe, Type> FinalizerSafe
+    for NodeRef<BorrowType, K, V, Type>
+{
+}
 
 unsafe impl<'a, K: Sync + 'a, V: Sync + 'a, Type> Send for NodeRef<marker::Immut<'a>, K, V, Type> {}
 unsafe impl<'a, K: Send + 'a, V: Send + 'a, Type> Send for NodeRef<marker::Mut<'a>, K, V, Type> {}

--- a/library/alloc/src/collections/linked_list.rs
+++ b/library/alloc/src/collections/linked_list.rs
@@ -1987,11 +1987,17 @@ unsafe impl<T: Send> Send for LinkedList<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for LinkedList<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for LinkedList<T> {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for Iter<'_, T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for Iter<'_, T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IterMut<'_, T> {}
@@ -1999,14 +2005,23 @@ unsafe impl<T: Send> Send for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for IterMut<'_, T> {}
+
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync> Send for Cursor<'_, T> {}
 
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync> Sync for Cursor<'_, T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for Cursor<'_, T> {}
+
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Send> Send for CursorMut<'_, T> {}
 
 #[unstable(feature = "linked_list_cursors", issue = "58533")]
 unsafe impl<T: Sync> Sync for CursorMut<'_, T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for CursorMut<'_, T> {}

--- a/library/alloc/src/collections/vec_deque/drain.rs
+++ b/library/alloc/src/collections/vec_deque/drain.rs
@@ -50,6 +50,8 @@ impl<T: fmt::Debug, A: Allocator> fmt::Debug for Drain<'_, T, A> {
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for Drain<'_, T, A> {}
 #[stable(feature = "drain", since = "1.6.0")]
 unsafe impl<T: Send, A: Allocator + Send> Send for Drain<'_, T, A> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe, A: Allocator + FinalizerSafe> FinalizerSafe for Drain<'_, T, A> {}
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl<T, A: Allocator> Drop for Drain<'_, T, A> {

--- a/library/alloc/src/collections/vec_deque/iter_mut.rs
+++ b/library/alloc/src/collections/vec_deque/iter_mut.rs
@@ -37,6 +37,9 @@ unsafe impl<T: Send> Send for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: core::marker::FinalizerSafe> core::marker::FinalizerSafe for IterMut<'_, T> {}
+
 #[stable(feature = "collection_debug", since = "1.17.0")]
 impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -31,7 +31,7 @@
 //! [`Cell`]: core::cell::Cell
 //! [`RefCell`]: core::cell::RefCell
 //! [send]: core::marker::Send
-//! [`Rc`]: core::rc::Rc
+//! [`Rc`]: crate::rc::Rc
 //! [`Deref`]: core::ops::Deref
 //! [mutability]: core::cell#introducing-mutability-inside-of-something-immutable
 //! [fully qualified syntax]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#fully-qualified-syntax-for-disambiguation-calling-methods-with-the-same-name
@@ -50,7 +50,7 @@ use core::{
     cmp::Ordering,
     fmt,
     hash::{Hash, Hasher},
-    marker::{PhantomData, Unsize},
+    marker::{FinalizerSafe, PhantomData, Unsize},
     mem::{ManuallyDrop, MaybeUninit},
     ops::{CoerceUnsized, Deref, DispatchFromDyn, Receiver},
     ptr::{null_mut, NonNull},
@@ -81,6 +81,15 @@ pub struct Gc<T: ?Sized> {
 
 unsafe impl<T: ?Sized + Send> Send for Gc<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for Gc<T> {}
+
+// In non-topological finalization, it is unsound to deref any fields of type
+// `Gc` from within a finalizer. This is because it could have been finalized
+// first, thus resulting in a dangling reference. Marking this as
+// `!FinalizerSafe` will give a nice compiler error if the user does so.
+//
+// FIXME: Make this conditional based on whether -DTOPOLOGICAL_FINALIZATION flag
+// is passed to the compiler.
+impl<T: ?Sized> !FinalizerSafe for Gc<T> {}
 
 impl<T: ?Sized> !NoTrace for Gc<T> {}
 

--- a/library/alloc/src/rc.rs
+++ b/library/alloc/src/rc.rs
@@ -314,6 +314,9 @@ pub struct Rc<T: ?Sized> {
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !marker::Send for Rc<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !marker::FinalizerSafe for Rc<T> {}
+
 // Note that this negative impl isn't strictly necessary for correctness,
 // as `Rc` transitively contains a `Cell`, which is itself `!Sync`.
 // However, given how important `Rc`'s `!Sync`-ness is,
@@ -2157,6 +2160,8 @@ pub struct Weak<T: ?Sized> {
 impl<T: ?Sized> !marker::Send for Weak<T> {}
 #[stable(feature = "rc_weak", since = "1.4.0")]
 impl<T: ?Sized> !marker::Sync for Weak<T> {}
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !marker::FinalizerSafe for Weak<T> {}
 
 #[unstable(feature = "coerce_unsized", issue = "27732")]
 impl<T: ?Sized + Unsize<U>, U: ?Sized> CoerceUnsized<Weak<U>> for Weak<T> {}

--- a/library/alloc/src/string.rs
+++ b/library/alloc/src/string.rs
@@ -2856,6 +2856,8 @@ impl fmt::Debug for Drain<'_> {
 unsafe impl Sync for Drain<'_> {}
 #[stable(feature = "drain", since = "1.6.0")]
 unsafe impl Send for Drain<'_> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl FinalizerSafe for Drain<'_> {}
 
 #[stable(feature = "drain", since = "1.6.0")]
 impl Drop for Drain<'_> {

--- a/library/alloc/src/sync.rs
+++ b/library/alloc/src/sync.rs
@@ -241,6 +241,8 @@ pub struct Arc<T: ?Sized> {
 unsafe impl<T: ?Sized + Sync + Send> Send for Arc<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Sync + Send> Sync for Arc<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for Arc<T> {}
 
 #[stable(feature = "catch_unwind", since = "1.9.0")]
 impl<T: RefUnwindSafe + ?Sized> UnwindSafe for Arc<T> {}
@@ -326,6 +328,7 @@ struct ArcInner<T: ?Sized> {
 
 unsafe impl<T: ?Sized + Sync + Send> Send for ArcInner<T> {}
 unsafe impl<T: ?Sized + Sync + Send> Sync for ArcInner<T> {}
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for ArcInner<T> {}
 
 impl<T> Arc<T> {
     /// Constructs a new `Arc<T>`.

--- a/library/alloc/src/vec/into_iter.rs
+++ b/library/alloc/src/vec/into_iter.rs
@@ -141,6 +141,8 @@ impl<T, A: Allocator> AsRef<[T]> for IntoIter<T, A> {
 unsafe impl<T: Send, A: Allocator + Send> Send for IntoIter<T, A> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync, A: Allocator + Sync> Sync for IntoIter<T, A> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe, A: Allocator + FinalizerSafe> FinalizerSafe for IntoIter<T, A> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T, A: Allocator> Iterator for IntoIter<T, A> {

--- a/library/core/src/cell.rs
+++ b/library/core/src/cell.rs
@@ -195,7 +195,7 @@
 use crate::cmp::Ordering;
 use crate::fmt::{self, Debug, Display};
 use crate::gc::NoFinalize;
-use crate::marker::{PhantomData, Unsize};
+use crate::marker::{FinalizerSafe, PhantomData, Unsize};
 use crate::mem;
 use crate::ops::{CoerceUnsized, Deref, DerefMut};
 use crate::ptr::{self, NonNull};
@@ -251,6 +251,9 @@ unsafe impl<T: ?Sized> Send for Cell<T> where T: Send {}
 
 #[unstable(feature = "gc", issue = "none")]
 unsafe impl<T: ?Sized> NoFinalize for Cell<T> where T: NoFinalize {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for Cell<T> {}
 
 // Note that this negative impl isn't strictly necessary for correctness,
 // as `Cell` wraps `UnsafeCell`, which is itself `!Sync`.
@@ -1158,6 +1161,9 @@ unsafe impl<T: ?Sized> Send for RefCell<T> where T: Send {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for RefCell<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for RefCell<T> {}
+
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: Clone> Clone for RefCell<T> {
     /// # Panics
@@ -1875,6 +1881,8 @@ pub struct UnsafeCell<T: ?Sized> {
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for UnsafeCell<T> {}
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for UnsafeCell<T> {}
 
 impl<T> UnsafeCell<T> {
     /// Constructs a new instance of `UnsafeCell` which will wrap the specified
@@ -2041,6 +2049,9 @@ pub struct SyncUnsafeCell<T: ?Sized> {
 
 #[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 unsafe impl<T: ?Sized + Sync> Sync for SyncUnsafeCell<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for SyncUnsafeCell<T> {}
 
 #[unstable(feature = "sync_unsafe_cell", issue = "95439")]
 impl<T> SyncUnsafeCell<T> {

--- a/library/core/src/future/mod.rs
+++ b/library/core/src/future/mod.rs
@@ -59,6 +59,9 @@ unsafe impl Send for ResumeTy {}
 #[unstable(feature = "gen_future", issue = "50547")]
 unsafe impl Sync for ResumeTy {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl FinalizerSafe for ResumeTy {}
+
 /// Wrap a generator in a future.
 ///
 /// This function returns a `GenFuture` underneath, but hides it in `impl Trait` to give

--- a/library/core/src/marker.rs
+++ b/library/core/src/marker.rs
@@ -482,6 +482,28 @@ impl<T: ?Sized> !Sync for *const T {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T: ?Sized> !Sync for *mut T {}
 
+/// Types for which it is safe to use inside a finalizer.
+///
+/// A `Gc` will finalize values on a separate thread. This means that a value
+/// used inside a `Gc` must have a thread-safe `Drop` implementation. In most
+/// cases, this is already covered if every type used inside the drop method
+/// implements `Send` + `Sync`.
+///
+/// The `FinalizerSafe` trait means that a type is safe to use inside a `Drop`
+/// implementation as part of a finalizer. It does not affect the `Send` +
+/// `Sync` status of a type, so implementating it does not have any adverse
+/// affects when used outside a `Gc`.
+#[unstable(feature = "gc", issue = "none")]
+#[cfg_attr(not(test), rustc_diagnostic_item = "FinalizerSafe")]
+pub unsafe auto trait FinalizerSafe {
+    // empty.
+}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for *const T {}
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for *mut T {}
+
 macro_rules! impls {
     ($t: ident) => {
         #[stable(feature = "rust1", since = "1.0.0")]
@@ -684,6 +706,11 @@ mod impls {
     unsafe impl<T: Sync + ?Sized> Send for &T {}
     #[stable(feature = "rust1", since = "1.0.0")]
     unsafe impl<T: Send + ?Sized> Send for &mut T {}
+
+    #[unstable(feature = "gc", issue = "none")]
+    unsafe impl<T: FinalizerSafe + ?Sized> FinalizerSafe for &T {}
+    #[unstable(feature = "gc", issue = "none")]
+    unsafe impl<T: FinalizerSafe + ?Sized> FinalizerSafe for &mut T {}
 }
 
 /// Compiler-internal trait used to indicate the type of enum discriminants.

--- a/library/core/src/prelude/v1.rs
+++ b/library/core/src/prelude/v1.rs
@@ -12,6 +12,10 @@ pub use crate::marker::{Copy, Send, Sized, Sync, Unpin};
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 
+#[unstable(feature = "gc", issue = "none")]
+#[doc(no_inline)]
+pub use crate::marker::FinalizerSafe;
+
 // Re-exported functions
 #[stable(feature = "core_prelude", since = "1.4.0")]
 #[doc(no_inline)]

--- a/library/core/src/ptr/metadata.rs
+++ b/library/core/src/ptr/metadata.rs
@@ -239,6 +239,7 @@ impl<Dyn: ?Sized> DynMetadata<Dyn> {
 
 unsafe impl<Dyn: ?Sized> Send for DynMetadata<Dyn> {}
 unsafe impl<Dyn: ?Sized> Sync for DynMetadata<Dyn> {}
+unsafe impl<Dyn: ?Sized> FinalizerSafe for DynMetadata<Dyn> {}
 
 impl<Dyn: ?Sized> fmt::Debug for DynMetadata<Dyn> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/core/src/ptr/non_null.rs
+++ b/library/core/src/ptr/non_null.rs
@@ -64,6 +64,9 @@ impl<T: ?Sized> !Send for NonNull<T> {}
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: ?Sized> !Sync for NonNull<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for NonNull<T> {}
+
 /// `NonNull` pointers are `NoTrace` if `T` is.
 #[stable(feature = "nonnull", since = "1.25.0")]
 impl<T: NoTrace> NoTrace for NonNull<T> {}

--- a/library/core/src/ptr/unique.rs
+++ b/library/core/src/ptr/unique.rs
@@ -53,6 +53,9 @@ pub struct Unique<T: ?Sized> {
 unsafe impl<T: Send + ?Sized> Send for Unique<T> {}
 
 #[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe + ?Sized> FinalizerSafe for Unique<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
 unsafe impl<T: ?Sized> OnlyFinalizeComponents for Unique<T> {}
 
 /// `Unique` pointers are `Sync` if `T` is `Sync` because the data they

--- a/library/core/src/slice/iter.rs
+++ b/library/core/src/slice/iter.rs
@@ -82,6 +82,8 @@ impl<T: fmt::Debug> fmt::Debug for Iter<'_, T> {
 unsafe impl<T: Sync> Sync for Iter<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Sync> Send for Iter<'_, T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: Sync> FinalizerSafe for Iter<'_, T> {}
 
 impl<'a, T> Iter<'a, T> {
     #[inline]
@@ -203,6 +205,8 @@ impl<T: fmt::Debug> fmt::Debug for IterMut<'_, T> {
 unsafe impl<T: Sync> Sync for IterMut<'_, T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: Send> Send for IterMut<'_, T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for IterMut<'_, T> {}
 
 impl<'a, T> IterMut<'a, T> {
     #[inline]

--- a/library/core/src/sync/atomic.rs
+++ b/library/core/src/sync/atomic.rs
@@ -193,6 +193,8 @@ unsafe impl<T> Send for AtomicPtr<T> {}
 #[cfg(target_has_atomic_load_store = "ptr")]
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T> Sync for AtomicPtr<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T> FinalizerSafe for AtomicPtr<T> {}
 
 /// Atomic memory orderings
 ///
@@ -1928,6 +1930,9 @@ macro_rules! atomic_int {
         // Send is implicitly implemented.
         #[$stable]
         unsafe impl Sync for $atomic_type {}
+
+        #[unstable(feature = "gc", issue = "none")]
+        unsafe impl core::marker::FinalizerSafe for $atomic_type {}
 
         impl $atomic_type {
             /// Creates a new atomic integer.

--- a/library/core/src/sync/exclusive.rs
+++ b/library/core/src/sync/exclusive.rs
@@ -89,6 +89,9 @@ pub struct Exclusive<T: ?Sized> {
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 unsafe impl<T: ?Sized> Sync for Exclusive<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized> FinalizerSafe for Exclusive<T> {}
+
 #[unstable(feature = "exclusive_wrapper", issue = "98407")]
 impl<T: ?Sized> fmt::Debug for Exclusive<T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {

--- a/library/core/src/task/wake.rs
+++ b/library/core/src/task/wake.rs
@@ -215,6 +215,8 @@ impl Unpin for Waker {}
 unsafe impl Send for Waker {}
 #[stable(feature = "futures_api", since = "1.36.0")]
 unsafe impl Sync for Waker {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl FinalizerSafe for Waker {}
 
 impl Waker {
     /// Wake up the task associated with this `Waker`.

--- a/library/proc_macro/src/bridge/buffer.rs
+++ b/library/proc_macro/src/bridge/buffer.rs
@@ -16,6 +16,7 @@ pub struct Buffer {
 
 unsafe impl Sync for Buffer {}
 unsafe impl Send for Buffer {}
+unsafe impl FinalizerSafe for Buffer {}
 
 impl Default for Buffer {
     #[inline]

--- a/library/proc_macro/src/bridge/client.rs
+++ b/library/proc_macro/src/bridge/client.rs
@@ -264,6 +264,7 @@ struct Bridge<'a> {
 
 impl<'a> !Send for Bridge<'a> {}
 impl<'a> !Sync for Bridge<'a> {}
+impl<'a> !FinalizerSafe for Bridge<'a> {}
 
 enum BridgeState<'a> {
     /// No server is currently connected to this client.

--- a/library/proc_macro/src/bridge/symbol.rs
+++ b/library/proc_macro/src/bridge/symbol.rs
@@ -21,6 +21,7 @@ pub struct Symbol(NonZeroU32);
 
 impl !Send for Symbol {}
 impl !Sync for Symbol {}
+impl !FinalizerSafe for Symbol {}
 
 impl Symbol {
     /// Intern a new `Symbol`

--- a/library/proc_macro/src/lib.rs
+++ b/library/proc_macro/src/lib.rs
@@ -32,6 +32,7 @@
 #![feature(rustc_attrs)]
 #![feature(min_specialization)]
 #![feature(strict_provenance)]
+#![feature(gc)]
 #![recursion_limit = "256"]
 
 #[unstable(feature = "proc_macro_internals", issue = "27812")]
@@ -82,6 +83,8 @@ pub struct TokenStream(Option<bridge::client::TokenStream>);
 impl !Send for TokenStream {}
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Sync for TokenStream {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for TokenStream {}
 
 /// Error returned from `TokenStream::from_str`.
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
@@ -103,6 +106,8 @@ impl error::Error for LexError {}
 impl !Send for LexError {}
 #[stable(feature = "proc_macro_lib", since = "1.15.0")]
 impl !Sync for LexError {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for LexError {}
 
 /// Error returned from `TokenStream::expand_expr`.
 #[unstable(feature = "proc_macro_expand", issue = "90765")]
@@ -125,6 +130,9 @@ impl !Send for ExpandError {}
 
 #[unstable(feature = "proc_macro_expand", issue = "90765")]
 impl !Sync for ExpandError {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for ExpandError {}
 
 impl TokenStream {
     /// Returns an empty `TokenStream` containing no token trees.
@@ -429,7 +437,8 @@ pub struct Span(bridge::client::Span);
 impl !Send for Span {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Span {}
-
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for Span {}
 macro_rules! diagnostic_method {
     ($name:ident, $level:expr) => {
         /// Creates a new `Diagnostic` with the given `message` at the span
@@ -602,6 +611,8 @@ impl LineColumn {
 impl !Send for LineColumn {}
 #[unstable(feature = "proc_macro_span", issue = "54725")]
 impl !Sync for LineColumn {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for LineColumn {}
 
 #[unstable(feature = "proc_macro_span", issue = "54725")]
 impl Ord for LineColumn {
@@ -691,6 +702,8 @@ pub enum TokenTree {
 impl !Send for TokenTree {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for TokenTree {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for TokenTree {}
 
 impl TokenTree {
     /// Returns the span of this tree, delegating to the `span` method of
@@ -799,6 +812,8 @@ pub struct Group(bridge::Group<bridge::client::TokenStream, bridge::client::Span
 impl !Send for Group {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Group {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for Group {}
 
 /// Describes how a sequence of token trees is delimited.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -940,6 +955,8 @@ pub struct Punct(bridge::Punct<bridge::client::Span>);
 impl !Send for Punct {}
 #[stable(feature = "proc_macro_lib2", since = "1.29.0")]
 impl !Sync for Punct {}
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for Punct {}
 
 /// Describes whether a `Punct` is followed immediately by another `Punct` ([`Spacing::Joint`]) or
 /// by a different token or whitespace ([`Spacing::Alone`]).

--- a/library/std/src/backtrace.rs
+++ b/library/std/src/backtrace.rs
@@ -155,6 +155,8 @@ pub struct BacktraceFrame {
     symbols: Vec<BacktraceSymbol>,
 }
 
+unsafe impl FinalizerSafe for BacktraceFrame {}
+
 #[derive(Debug)]
 enum RawFrame {
     Actual(backtrace_rs::Frame),
@@ -450,6 +452,8 @@ impl LazilyResolvedCapture {
 // SAFETY: Access to the inner value is synchronized using a thread-safe `Once`
 // So long as `Capture` is `Sync`, `LazilyResolvedCapture` is too
 unsafe impl Sync for LazilyResolvedCapture where Capture: Sync {}
+
+unsafe impl FinalizerSafe for LazilyResolvedCapture where Capture: FinalizerSafe {}
 
 impl Capture {
     fn resolve(&mut self) {

--- a/library/std/src/env.rs
+++ b/library/std/src/env.rs
@@ -798,6 +798,9 @@ impl !Send for Args {}
 #[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for Args {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for Args {}
+
 #[stable(feature = "env", since = "1.0.0")]
 impl Iterator for Args {
     type Item = String;
@@ -838,6 +841,9 @@ impl !Send for ArgsOs {}
 
 #[stable(feature = "env_unimpl_send_sync", since = "1.26.0")]
 impl !Sync for ArgsOs {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl !FinalizerSafe for ArgsOs {}
 
 #[stable(feature = "env", since = "1.0.0")]
 impl Iterator for ArgsOs {

--- a/library/std/src/io/error/repr_bitpacked.rs
+++ b/library/std/src/io/error/repr_bitpacked.rs
@@ -130,6 +130,7 @@ pub(super) struct Repr(NonNull<()>, PhantomData<ErrorData<Box<Custom>>>);
 // All the types `Repr` stores internally are Send + Sync, and so is it.
 unsafe impl Send for Repr {}
 unsafe impl Sync for Repr {}
+unsafe impl FinalizerSafe for Repr {}
 
 impl Repr {
     pub(super) fn new(dat: ErrorData<Box<Custom>>) -> Self {

--- a/library/std/src/io/mod.rs
+++ b/library/std/src/io/mod.rs
@@ -1060,6 +1060,9 @@ unsafe impl<'a> Send for IoSliceMut<'a> {}
 #[stable(feature = "iovec-send-sync", since = "1.44.0")]
 unsafe impl<'a> Sync for IoSliceMut<'a> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<'a> core::marker::FinalizerSafe for IoSliceMut<'a> {}
+
 #[stable(feature = "iovec", since = "1.36.0")]
 impl<'a> fmt::Debug for IoSliceMut<'a> {
     fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -1202,6 +1205,9 @@ unsafe impl<'a> Send for IoSlice<'a> {}
 
 #[stable(feature = "iovec-send-sync", since = "1.44.0")]
 unsafe impl<'a> Sync for IoSlice<'a> {}
+
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<'a> FinalizerSafe for IoSlice<'a> {}
 
 #[stable(feature = "iovec", since = "1.36.0")]
 impl<'a> fmt::Debug for IoSlice<'a> {

--- a/library/std/src/prelude/v1.rs
+++ b/library/std/src/prelude/v1.rs
@@ -12,6 +12,10 @@ pub use crate::marker::{Send, Sized, Sync, Unpin};
 #[doc(no_inline)]
 pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
 
+#[unstable(feature = "gc", issue = "none")]
+#[doc(no_inline)]
+pub use crate::marker::FinalizerSafe;
+
 // Re-exported functions
 #[stable(feature = "rust1", since = "1.0.0")]
 #[doc(no_inline)]

--- a/library/std/src/sync/lazy_lock.rs
+++ b/library/std/src/sync/lazy_lock.rs
@@ -112,6 +112,9 @@ impl<T: fmt::Debug, F> fmt::Debug for LazyLock<T, F> {
 unsafe impl<T, F: Send> Sync for LazyLock<T, F> where OnceLock<T>: Sync {}
 // auto-derived `Send` impl is OK.
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T, F: FinalizerSafe> FinalizerSafe for LazyLock<T, F> where OnceLock<T>: FinalizerSafe {}
+
 #[unstable(feature = "once_cell", issue = "74465")]
 impl<T, F: UnwindSafe> RefUnwindSafe for LazyLock<T, F> where OnceLock<T>: RefUnwindSafe {}
 #[unstable(feature = "once_cell", issue = "74465")]

--- a/library/std/src/sync/mpsc/blocking.rs
+++ b/library/std/src/sync/mpsc/blocking.rs
@@ -12,6 +12,7 @@ struct Inner {
 
 unsafe impl Send for Inner {}
 unsafe impl Sync for Inner {}
+unsafe impl FinalizerSafe for Inner {}
 
 #[derive(Clone)]
 pub struct SignalToken {
@@ -25,6 +26,8 @@ pub struct WaitToken {
 impl !Send for WaitToken {}
 
 impl !Sync for WaitToken {}
+
+impl !FinalizerSafe for WaitToken {}
 
 pub fn tokens() -> (WaitToken, SignalToken) {
     let inner = Arc::new(Inner { thread: thread::current(), woken: AtomicBool::new(false) });

--- a/library/std/src/sync/mpsc/mod.rs
+++ b/library/std/src/sync/mpsc/mod.rs
@@ -352,6 +352,9 @@ unsafe impl<T: Send> Send for Receiver<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for Receiver<T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+impl<T> !FinalizerSafe for Receiver<T> {}
+
 /// An iterator over messages on a [`Receiver`], created by [`iter`].
 ///
 /// This iterator will block whenever [`next`] is called,
@@ -508,6 +511,9 @@ unsafe impl<T: Send> Send for Sender<T> {}
 
 #[stable(feature = "rust1", since = "1.0.0")]
 impl<T> !Sync for Sender<T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T> !FinalizerSafe for Sender<T> {}
 
 /// The sending-half of Rust's synchronous [`sync_channel`] type.
 ///

--- a/library/std/src/sync/mpsc/mpsc_queue.rs
+++ b/library/std/src/sync/mpsc/mpsc_queue.rs
@@ -50,6 +50,7 @@ pub struct Queue<T> {
 
 unsafe impl<T: Send> Send for Queue<T> {}
 unsafe impl<T: Send> Sync for Queue<T> {}
+unsafe impl<T: Send + FinalizerSafe> FinalizerSafe for Queue<T> {}
 
 impl<T> Node<T> {
     unsafe fn new(v: Option<T>) -> *mut Node<T> {

--- a/library/std/src/sync/mpsc/spsc_queue.rs
+++ b/library/std/src/sync/mpsc/spsc_queue.rs
@@ -58,6 +58,11 @@ unsafe impl<T: Send, P: Send + Sync, C: Send + Sync> Send for Queue<T, P, C> {}
 
 unsafe impl<T: Send, P: Send + Sync, C: Send + Sync> Sync for Queue<T, P, C> {}
 
+unsafe impl<T: Send, P: Send + FinalizerSafe, C: Send + FinalizerSafe> FinalizerSafe
+    for Queue<T, P, C>
+{
+}
+
 impl<T> Node<T> {
     fn new() -> *mut Node<T> {
         Box::into_raw(box Node {

--- a/library/std/src/sync/mpsc/sync.rs
+++ b/library/std/src/sync/mpsc/sync.rs
@@ -48,6 +48,8 @@ unsafe impl<T: Send> Send for Packet<T> {}
 
 unsafe impl<T: Send> Sync for Packet<T> {}
 
+unsafe impl<T: Send + FinalizerSafe> FinalizerSafe for Packet<T> {}
+
 struct State<T> {
     disconnected: bool, // Is the channel disconnected yet?
     queue: Queue,       // queue of senders waiting to send data

--- a/library/std/src/sync/mutex.rs
+++ b/library/std/src/sync/mutex.rs
@@ -174,6 +174,8 @@ pub struct Mutex<T: ?Sized> {
 unsafe impl<T: ?Sized + Send> Send for Mutex<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send> Sync for Mutex<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for Mutex<T> {}
 
 /// An RAII implementation of a "scoped lock" of a mutex. When this structure is
 /// dropped (falls out of scope), the lock will be unlocked.
@@ -201,6 +203,8 @@ pub struct MutexGuard<'a, T: ?Sized + 'a> {
 impl<T: ?Sized> !Send for MutexGuard<'_, T> {}
 #[stable(feature = "mutexguard", since = "1.19.0")]
 unsafe impl<T: ?Sized + Sync> Sync for MutexGuard<'_, T> {}
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for MutexGuard<'_, T> {}
 
 impl<T> Mutex<T> {
     /// Creates a new mutex in an unlocked state ready for use.

--- a/library/std/src/sync/once.rs
+++ b/library/std/src/sync/once.rs
@@ -126,6 +126,8 @@ pub struct Once {
 unsafe impl Sync for Once {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl Send for Once {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl FinalizerSafe for Once {}
 
 #[stable(feature = "sync_once_unwind_safe", since = "1.59.0")]
 impl UnwindSafe for Once {}

--- a/library/std/src/sync/once_lock.rs
+++ b/library/std/src/sync/once_lock.rs
@@ -391,6 +391,8 @@ impl<T> OnceLock<T> {
 unsafe impl<T: Sync + Send> Sync for OnceLock<T> {}
 #[unstable(feature = "once_cell", issue = "74465")]
 unsafe impl<T: Send> Send for OnceLock<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: FinalizerSafe> FinalizerSafe for OnceLock<T> {}
 
 #[unstable(feature = "once_cell", issue = "74465")]
 impl<T: RefUnwindSafe + UnwindSafe> RefUnwindSafe for OnceLock<T> {}

--- a/library/std/src/sync/rwlock.rs
+++ b/library/std/src/sync/rwlock.rs
@@ -86,6 +86,8 @@ pub struct RwLock<T: ?Sized> {
 unsafe impl<T: ?Sized + Send> Send for RwLock<T> {}
 #[stable(feature = "rust1", since = "1.0.0")]
 unsafe impl<T: ?Sized + Send + Sync> Sync for RwLock<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for RwLock<T> {}
 
 /// RAII structure used to release the shared read access of a lock when
 /// dropped.
@@ -116,6 +118,9 @@ impl<T: ?Sized> !Send for RwLockReadGuard<'_, T> {}
 #[stable(feature = "rwlock_guard_sync", since = "1.23.0")]
 unsafe impl<T: ?Sized + Sync> Sync for RwLockReadGuard<'_, T> {}
 
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T: ?Sized + FinalizerSafe> FinalizerSafe for RwLockReadGuard<'_, T> {}
+
 /// RAII structure used to release the exclusive write access of a lock when
 /// dropped.
 ///
@@ -140,6 +145,9 @@ impl<T: ?Sized> !Send for RwLockWriteGuard<'_, T> {}
 
 #[stable(feature = "rwlock_guard_sync", since = "1.23.0")]
 unsafe impl<T: ?Sized + Sync> Sync for RwLockWriteGuard<'_, T> {}
+
+#[unstable(feature = "gc", issue = "none")]
+impl<T: ?Sized> !FinalizerSafe for RwLockWriteGuard<'_, T> {}
 
 impl<T> RwLock<T> {
     /// Creates a new instance of an `RwLock<T>` which is unlocked.

--- a/library/std/src/sys/unix/args.rs
+++ b/library/std/src/sys/unix/args.rs
@@ -25,6 +25,7 @@ pub struct Args {
 
 impl !Send for Args {}
 impl !Sync for Args {}
+impl !FinalizerSafe for Args {}
 
 impl fmt::Debug for Args {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/library/std/src/sys/unix/fs.rs
+++ b/library/std/src/sys/unix/fs.rs
@@ -245,6 +245,7 @@ struct Dir(*mut libc::DIR);
 
 unsafe impl Send for Dir {}
 unsafe impl Sync for Dir {}
+unsafe impl FinalizerSafe for Dir {}
 
 #[cfg(any(
     target_os = "android",

--- a/library/std/src/sys/unix/os.rs
+++ b/library/std/src/sys/unix/os.rs
@@ -477,6 +477,7 @@ pub struct Env {
 
 impl !Send for Env {}
 impl !Sync for Env {}
+impl !FinalizerSafe for Env {}
 
 impl Iterator for Env {
     type Item = (OsString, OsString);

--- a/library/std/src/sys/unix/process/process_common.rs
+++ b/library/std/src/sys/unix/process/process_common.rs
@@ -93,6 +93,7 @@ struct Argv(Vec<*const c_char>);
 // pointers to memory owned by `Command.args`
 unsafe impl Send for Argv {}
 unsafe impl Sync for Argv {}
+unsafe impl FinalizerSafe for Argv {}
 
 // passed back to std::process with the pipes connected to the child, if any
 // were requested

--- a/library/std/src/sys/unix/thread.rs
+++ b/library/std/src/sys/unix/thread.rs
@@ -45,6 +45,7 @@ pub struct Thread {
 // a thread to be Send/Sync
 unsafe impl Send for Thread {}
 unsafe impl Sync for Thread {}
+unsafe impl FinalizerSafe for Thread {}
 
 impl Thread {
     // unsafe: see thread::Builder::spawn_unchecked for safety requirements

--- a/library/std/src/sys_common/mutex.rs
+++ b/library/std/src/sys_common/mutex.rs
@@ -12,6 +12,7 @@ use crate::sys::locks as imp;
 pub struct StaticMutex(imp::Mutex);
 
 unsafe impl Sync for StaticMutex {}
+unsafe impl FinalizerSafe for StaticMutex {}
 
 impl StaticMutex {
     /// Creates a new mutex for use.
@@ -57,6 +58,8 @@ impl Drop for StaticMutexGuard {
 pub struct MovableMutex(imp::MovableMutex);
 
 unsafe impl Sync for MovableMutex {}
+
+unsafe impl FinalizerSafe for MovableMutex {}
 
 impl MovableMutex {
     /// Creates a new mutex.

--- a/library/std/src/sys_common/net.rs
+++ b/library/std/src/sys_common/net.rs
@@ -164,6 +164,7 @@ impl Iterator for LookupHost {
 
 unsafe impl Sync for LookupHost {}
 unsafe impl Send for LookupHost {}
+unsafe impl FinalizerSafe for LookupHost {}
 
 impl Drop for LookupHost {
     fn drop(&mut self) {

--- a/library/std/src/sys_common/remutex.rs
+++ b/library/std/src/sys_common/remutex.rs
@@ -50,6 +50,7 @@ pub struct ReentrantMutex<T> {
 
 unsafe impl<T: Send> Send for ReentrantMutex<T> {}
 unsafe impl<T: Send> Sync for ReentrantMutex<T> {}
+unsafe impl<T: Send + FinalizerSafe> FinalizerSafe for ReentrantMutex<T> {}
 
 impl<T> UnwindSafe for ReentrantMutex<T> {}
 impl<T> RefUnwindSafe for ReentrantMutex<T> {}

--- a/library/std/src/thread/local.rs
+++ b/library/std/src/thread/local.rs
@@ -1058,6 +1058,8 @@ pub mod os {
 
     unsafe impl<T> Sync for Key<T> {}
 
+    unsafe impl<T> FinalizerSafe for Key<T> {}
+
     struct Value<T: 'static> {
         inner: LazyKeyInner<T>,
         key: &'static Key<T>,

--- a/library/std/src/thread/mod.rs
+++ b/library/std/src/thread/mod.rs
@@ -1329,6 +1329,8 @@ struct Packet<'scope, T> {
 // `UnsafeCell` synchronized (by the `join()` boundary), and `ScopeData` is Sync.
 unsafe impl<'scope, T: Sync> Sync for Packet<'scope, T> {}
 
+unsafe impl<'scope, T: FinalizerSafe> FinalizerSafe for Packet<'scope, T> {}
+
 impl<'scope, T> Drop for Packet<'scope, T> {
     fn drop(&mut self) {
         // If this packet was for a thread that ran in a scope, the thread
@@ -1444,6 +1446,8 @@ pub struct JoinHandle<T>(JoinInner<'static, T>);
 unsafe impl<T> Send for JoinHandle<T> {}
 #[stable(feature = "joinhandle_impl_send_sync", since = "1.29.0")]
 unsafe impl<T> Sync for JoinHandle<T> {}
+#[unstable(feature = "gc", issue = "none")]
+unsafe impl<T> FinalizerSafe for JoinHandle<T> {}
 
 impl<T> JoinHandle<T> {
     /// Extracts a handle to the underlying thread.

--- a/src/test/rustdoc/empty-section.rs
+++ b/src/test/rustdoc/empty-section.rs
@@ -8,6 +8,7 @@ pub struct Foo;
 // @!has - 'Auto Trait Implementations'
 impl !Send for Foo {}
 impl !Sync for Foo {}
+impl !FinalizerSafe for Foo {}
 impl !std::marker::Unpin for Foo {}
 impl !std::panic::RefUnwindSafe for Foo {}
 impl !std::panic::UnwindSafe for Foo {}

--- a/src/test/rustdoc/issue-50159.rs
+++ b/src/test/rustdoc/issue-50159.rs
@@ -13,8 +13,9 @@ impl<B, C> Signal2 for B where B: Signal<Item = C> {
 // @has issue_50159/struct.Switch.html
 // @has - '//h3[@class="code-header in-band"]' 'impl<B> Send for Switch<B> where <B as Signal>::Item: Send'
 // @has - '//h3[@class="code-header in-band"]' 'impl<B> Sync for Switch<B> where <B as Signal>::Item: Sync'
+// @has - '//h3[@class="code-header in-band"]' 'impl<B> FinalizerSafe for Switch<B> where <B as Signal>::Item: FinalizerSafe'
 // @count - '//*[@id="implementations-list"]//*[@class="impl"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 6
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 7
 pub struct Switch<B: Signal> {
     pub inner: <B as Signal2>::Item2,
 }

--- a/src/test/rustdoc/synthetic_auto/basic.rs
+++ b/src/test/rustdoc/synthetic_auto/basic.rs
@@ -1,8 +1,9 @@
 // @has basic/struct.Foo.html
 // @has - '//h3[@class="code-header in-band"]' 'impl<T> Send for Foo<T> where T: Send'
 // @has - '//h3[@class="code-header in-band"]' 'impl<T> Sync for Foo<T> where T: Sync'
+// @has - '//h3[@class="code-header in-band"]' 'impl<T> FinalizerSafe for Foo<T> where T: FinalizerSafe'
 // @count - '//*[@id="implementations-list"]//*[@class="impl has-srclink"]' 0
-// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 6
+// @count - '//*[@id="synthetic-implementations-list"]//*[@class="impl has-srclink"]' 7
 pub struct Foo<T> {
     field: T,
 }

--- a/src/test/ui/gc/check_finalizers.rs
+++ b/src/test/ui/gc/check_finalizers.rs
@@ -1,17 +1,87 @@
-// check-fail
 #![feature(gc)]
+#![feature(negative_impls)]
 
 use std::gc::Gc;
+use std::rc::Rc;
+use std::cell::Cell;
+use std::marker::FinalizerSafe;
 
-struct Hello(*mut u8);
+struct ShouldPass(*mut u8);
 
-impl Drop for Hello {
+impl Drop for ShouldPass {
+    // Drop doesn't do anything dangerous, so this shouldn't bork.
     fn drop(&mut self) {
         println!("Dropping Hello");
     }
 }
 
+struct ShouldFail(Cell<usize>);
+
+impl !FinalizerSafe for ShouldFail{}
+
+impl Drop for ShouldFail {
+    // We mutate via an unsynchronized field here, this should bork.
+    fn drop(&mut self) {
+        self.0.replace(456);
+    }
+}
+
+trait Opaque {}
+
+impl Opaque for ShouldPass {}
+
+struct HasGcFields(Gc<usize>);
+
+impl Drop for HasGcFields {
+    fn drop(&mut self) {
+        println!("Boom {}", self.0);
+    }
+}
+
+struct ShouldFail2(*mut u8);
+
+impl ShouldFail2 {
+    #[inline(never)]
+    fn foo(&mut self) {}
+}
+
+impl Drop for ShouldFail2 {
+    fn drop(&mut self) {
+        self.foo();
+    }
+}
+
+struct ShouldPassInFuture(*mut u8);
+
+impl !FinalizerSafe for ShouldPassInFuture {}
+
+impl ShouldPassInFuture {
+    fn transparent(&self) {
+        println!("Value is {:?}", self.0);
+    }
+}
+
+impl Drop for ShouldPassInFuture {
+    fn drop(&mut self) {
+        let x = ShouldPassInFuture(456 as *mut u8);
+        x.transparent();
+    }
+}
+
 fn main() {
-    Gc::new(Hello(123 as *mut u8)); //~ ERROR `Hello(123 as *mut u8)` cannot be safely finalized.
-    //~| ERROR `Hello(123 as *mut u8)` cannot be safely finalized.
+    Gc::new(ShouldPass(123 as *mut u8));
+
+    Gc::new(ShouldFail(Cell::new(123))); //~ ERROR: `ShouldFail(Cell::new(123))` cannot be safely finalized.
+
+    let boxed_trait: Box<dyn Opaque> = Box::new(ShouldPass(123 as *mut u8));
+    Gc::new(boxed_trait); //~ ERROR: `boxed_trait` cannot be safely finalized.
+
+    let gcfields = HasGcFields(Gc::new(123));
+    Gc::new(gcfields); //~ ERROR: `gcfields` cannot be safely finalized.
+
+    let self_call = ShouldFail2(123 as *mut u8);
+    Gc::new(self_call); //~ ERROR: `self_call` cannot be safely finalized.
+
+    let transparent_call = ShouldPassInFuture(123 as *mut u8);
+    Gc::new(transparent_call); //~ ERROR: `transparent_call` cannot be safely finalized.
 }

--- a/src/test/ui/gc/check_finalizers.stderr
+++ b/src/test/ui/gc/check_finalizers.stderr
@@ -1,24 +1,72 @@
-error: `Hello(123 as *mut u8)` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:15:13
+error: `ShouldFail(Cell::new(123))` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:74:13
    |
-LL |     Gc::new(Hello(123 as *mut u8));
-   |     --------^^^^^^^^^^^^^^^^^^^^^-
+LL |         self.0.replace(456);
+   |         -------------------
+   |         |
+   |         caused by the expression in `fn drop(&mut)` here because
+   |         it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(ShouldFail(Cell::new(123)));
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
+
+error: `boxed_trait` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:77:13
+   |
+LL |     Gc::new(boxed_trait);
+   |     --------^^^^^^^^^^^-
    |     |       |
    |     |       has a drop method which cannot be safely finalized.
-   |     `Gc::new` requires that it implements the `Send` trait.
+   |     `Gc::new` requires that it implements the `FinalizeSafe` trait.
    |
-   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Send` in order to be safely dropped
+   = help: `Gc` runs finalizers on a separate thread, so `boxed_trait` must implement `FinalizeSafe` in order to be safely dropped.
 
-error: `Hello(123 as *mut u8)` cannot be safely finalized.
-  --> $DIR/check_finalizers.rs:15:13
+error: `gcfields` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:80:13
    |
-LL |     Gc::new(Hello(123 as *mut u8));
-   |     --------^^^^^^^^^^^^^^^^^^^^^-
-   |     |       |
-   |     |       has a drop method which cannot be safely finalized.
-   |     `Gc::new` requires that it implements the `Sync` trait.
+LL |         println!("Boom {}", self.0);
+   |                             ------
+   |                             |
+   |                             caused by the expression here in `fn drop(&mut)` because
+   |                             it uses another `Gc` type.
+...
+LL |     Gc::new(gcfields);
+   |             ^^^^^^^^ has a drop method which cannot be safely finalized.
    |
-   = help: `Gc` runs finalizers on a separate thread, so `Hello(123 as *mut u8)` must implement `Sync` in order to be safely dropped
+   = help: `Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.
 
-error: aborting due to 2 previous errors
+error: `self_call` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:83:13
+   |
+LL |         self.foo();
+   |         ----------
+   |         |
+   |         caused by the expression in `fn drop(&mut)` here because
+   |         it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(self_call);
+   |             ^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
+
+error: `transparent_call` cannot be safely finalized.
+  --> $DIR/check_finalizers.rs:86:13
+   |
+LL |         let x = ShouldPassInFuture(456 as *mut u8);
+   |                 ----------------------------------
+   |                 |
+   |                 caused by the expression in `fn drop(&mut)` here because
+   |                 it uses a type which is not safe to use in a finalizer.
+...
+LL |     Gc::new(transparent_call);
+   |             ^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
+   |
+   = help: `Gc` runs finalizers on a separate thread, so drop methods
+           must only use values whose types implement `Send + Sync` or `FinalizerSafe`.
+
+error: aborting due to 5 previous errors
 


### PR DESCRIPTION
This change lets us accept *a lot* more types for `Gc<T>`. In f1757e, we check if `T` implements `Drop`, and if it does, we then check that `T: Send + Sync`. This commit improves the algorithm to now do the following:

1. Instead, check if `T: FinalizerSafe`, which is set up to have all the same bounds as `T: Send + Sync` in the standard library.

2. If `T: !FinalizerSafe`, look at all the drop methods that `T` needs to call. That means `T`s drop method, and any drop methods of `T`s component types.

3. Look at the MIR for each of these drop methods, if any of them contain a projection into a field which is not `FinalizerSafe` then emit a compiler error, showing the exact line inside `drop` which is unsound.

This makes `Gc` much safer to use, because there are types which implement `Drop` which are not `Send + Sync`, but they don't do anything in `Drop` in a thread-unsafe way. We can now make use of Rust's ability to detect races at compile-time to ensure we have safe drop calls inside finalizers.

This also lets us prevent users from derefing `Gc` fields inside finalizers, as we mark `Gc` as `!FinalizerSafe` *but* leave it `Send + Sync` if its contents are.

This can be better understood with an example. Consider the following Rust program which performs a non-thread-safe operation inside its `drop` method.

```rust

    struct S(Rc<Cell<String>>);

    impl !std::marker::FinalizerSafe for S{}

    impl Drop for S {
        fn drop(&mut self) {
            self.0.replace("World".to_string());
        }
    }

    fn main() {
        let rc = Rc::new(Cell::new("Hello".to_string()));
        let gc = Gc::new(S(Rc::clone(&rc)));
    }

```
This will give the following compiler error:

```
error: `S(Rc::clone(&rc))` cannot be safely finalized.
  --> src/main.rs:19:22
   |
13 |         self.0.replace("World".to_string());
   |         -----------------------------------
   |         |
   |         caused by the expression in `fn drop(&mut)` here because
   |         it uses a type which is not safe to use in a finalizer.
...
19 |     let gc = Gc::new(S(Rc::clone(&rc)));
   |                      ^^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
   |
   = help: `Gc` runs finalizers on a separate thread, so drop methods
           must only use values whose types implement `FinalizerSafe`.
```

Here's another example where we erroneously use a `Gc` field inside a finalizer:

```rust
struct HasGcFields(Gc<usize>);

impl Drop for HasGcFields {
    fn drop(&mut self) {
        println!("Boom {}", self.0);
    }
}

fn main() {
    Gc::new(HasGcFields(Gc::new(123)));
}
```

Which gives the following error:

```
error: `HasGcFields(Gc::new(123))` cannot be safely finalized.
  --> src/main.rs:18:13
   |
13 |         println!("Boom {}", self.0);
   |                             ------
   |                             |
   |                             caused by the expression in `fn drop(&mut)` here because
   |                             it uses another `Gc` type.
...
18 |     Gc::new(HasGcFields(Gc::new(123)));
   |             ^^^^^^^^^^^^^^^^^^^^^^^^^ has a drop method which cannot be safely finalized.
   |
   = help: `Gc` finalizers are unordered, so this field may have already been dropped. It is not safe to dereference.
```