### PR TITLE
`as_ptr` typically takes `&Self`.

### DIFF
--- a/library/alloc/src/gc.rs
+++ b/library/alloc/src/gc.rs
@@ -126,7 +126,7 @@ impl<T: ?Sized> Gc<T> {
 
     /// Get a raw pointer to the underlying value `T`.
     #[unstable(feature = "gc", issue = "none")]
-    pub fn as_ptr(this: Self) -> *const T {
+    pub fn as_ptr(this: &Self) -> *const T {
         this.ptr.as_ptr() as *const T
     }
 


### PR DESCRIPTION
This better matches `Rc::as_ptr` and friends. Practically speaking, it doesn't make much difference to `Gc` since `Gc` is `Copy`, but using `as_ptr(&Self)` forces callers to add a `&` reference which then makes converting `Gc::as_ptr` to `Rc::as_ptr` easier.