### PR TITLE
Update `NonFinalizable` container

### DIFF
--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -1023,6 +1023,7 @@ symbols! {
         non_ascii_idents,
         non_exhaustive,
         non_exhaustive_omitted_patterns_lint,
+        non_finalizable,
         non_modrs_mods,
         none_error,
         nontemporal_store,

--- a/compiler/rustc_ty_utils/src/needs_finalizer.rs
+++ b/compiler/rustc_ty_utils/src/needs_finalizer.rs
@@ -5,7 +5,7 @@ use rustc_hir::def_id::DefId;
 use rustc_middle::ty::util::{needs_drop_components, AlwaysRequiresDrop};
 use rustc_middle::ty::{self, EarlyBinder, Subst, Ty, TyCtxt};
 use rustc_session::Limit;
-use rustc_span::DUMMY_SP;
+use rustc_span::{sym, DUMMY_SP};
 
 type NeedsDropResult<T> = Result<T, AlwaysRequiresDrop>;
 
@@ -118,6 +118,10 @@ where
                     // `ManuallyDrop`. If it's a struct or enum without a `Drop`
                     // impl then check whether the field types need `Drop`.
                     ty::Adt(adt_def, substs) => {
+                        if adt_def.did() == tcx.get_diagnostic_item(sym::non_finalizable).unwrap() {
+                            continue;
+                        }
+
                         let finalizer_optional =
                             component.finalizer_optional(tcx.at(DUMMY_SP), self.param_env);
 

--- a/library/core/src/gc.rs
+++ b/library/core/src/gc.rs
@@ -34,10 +34,12 @@ pub struct Trace {
 
 /// A wrapper which prevents `T` from being finalized when used in a `Gc`.
 ///
-/// This has the same effect as implementing `NoFinalize` trait on `T`, however,
-/// due to the orphan rule this is not always possible. `NonFinalizable` acts as
-/// a convenience wrapper.
-#[derive(Debug)]
+/// This is useful for when its not possible to implement `FinalizerOptional`
+/// because of the orphan rule. However, if `NonFinalizable<T>` is used as a
+/// field type of another type which is finalizable, then `T` will also be
+/// finalized.
+#[derive(Debug, PartialEq, Eq)]
+#[rustc_diagnostic_item = "non_finalizable"]
 pub struct NonFinalizable<T: ?Sized>(T);
 
 impl<T> NonFinalizable<T> {

--- a/src/test/ui/gc/needs_finalize.rs
+++ b/src/test/ui/gc/needs_finalize.rs
@@ -4,7 +4,7 @@
 
 use std::mem;
 use std::rc::Rc;
-use std::gc::{Gc, FinalizerOptional};
+use std::gc::{Gc, FinalizerOptional, NonFinalizable};
 
 struct HasDrop;
 
@@ -73,6 +73,9 @@ static NESTED_GC: bool = mem::needs_finalizer::<Box<Gc<HasDrop>>>();
 static RC: bool = mem::needs_finalizer::<Rc<HasDrop>>();
 static NESTED_GC_NO_FINALIZE: bool = mem::needs_finalizer::<Box<Gc<NonAnnotated>>>();
 
+static NON_FINALIZABLE: bool = mem::needs_finalizer::<NonFinalizable<HasDrop>>();
+static NON_FINALIZABLE_NESTED: bool = mem::needs_finalizer::<MaybeFinalize<NonFinalizable<HasDrop>>>();
+
 fn main() {
     assert!(!CONST_U8);
     assert!(!CONST_STRING);
@@ -114,4 +117,7 @@ fn main() {
     assert!(!NESTED_GC);
     assert!(RC);
     assert!(!NESTED_GC_NO_FINALIZE);
+
+    assert!(!NON_FINALIZABLE);
+    assert!(!NON_FINALIZABLE_NESTED);
 }


### PR DESCRIPTION
Sometimes it's necessary to prevent finalization on a per-use basis. This can happen when it's not possible to implement `FinalizerOptional` on types because were defined outside of the current crate (due to the orphan rule).

This updates the `NonFinalizable` container to respect the new semantics and adds some tests for it.