### PR TITLE
Add config for benchmarking programs with Alloy

### DIFF
--- a/benchmark.config.toml
+++ b/benchmark.config.toml
@@ -1,0 +1,18 @@
+# TOML configuration used for benchmarking Rust programs built with Alloy.
+
+[rust]
+codegen-units = 0           # Use many compilation units.
+optimize = true
+debug = false
+
+[build]
+install-stage = 2
+
+[llvm]
+optimize = true
+assertions = false
+ninja = true
+
+[install]
+prefix = "build/alloy-stage2-latest"
+sysconfdir = "etc"


### PR DESCRIPTION
Most of these options are the default when building rustc with stage 2. It's useful have an explicit config for them so that nothing changes while we are conducting experiments.